### PR TITLE
Add locale middleware for localized routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,53 @@ Setting this option to `'en'` will result, for example, in URL's like this:
 
 > This option has no effect if you use domains instead of slugs.
 
+#### Automatically Set Locale for Localized Routes
+
+To automatically set the locale when a localized route is active via a middleware simply set the option to true:
+
+```php
+'use_locale_middleware' => true
+```
+
+Alternatively, you can omit it completely or specify it for a specific route or route group:
+
+```php
+Route::localized(function () {
+
+    Route::get('about', AboutController::class.'@index')
+        ->name('about')
+        ->middleware(\CodeZero\LocalizedRoutes\Middleware\LocalizedRouteLocaleHandler::class);
+
+    Route::group(
+        [
+            'as' => 'admin.',
+            'middleware' => [\CodeZero\LocalizedRoutes\Middleware\LocalizedRouteLocaleHandler::class],
+        ],
+        function () {
+            Route::get('admin/reports', ReportsController::class.'@index')
+                ->name('reports.index');
+        });
+
+});
+```
+
+#### ☑️ Set Options for the Current Localized Route Group
+
+To set an option for one localized route group only, you can specify it as the second parameter of the localized route macro:
+
+```php
+Route::localized(function () {
+
+    Route::get('about', AboutController::class.'@index')
+        ->name('about');
+
+}, [
+    'supported-locales' => ['en', 'nl', 'fr'],
+    'omit_url_prefix_for_locale' => null,
+    'use_locale_middleware' => false,
+]);
+```
+
 ## 🚗 Register Routes
 
 Example:

--- a/config/localized-routes.php
+++ b/config/localized-routes.php
@@ -15,4 +15,10 @@ return [
      */
     'omit_url_prefix_for_locale' => null,
 
+    /**
+     * If you want to automatically set the locale
+     * for localized routes set this to true.
+     */
+    'use_locale_middleware' => false,
+
 ];

--- a/src/Middleware/LocalizedRouteLocaleHandler.php
+++ b/src/Middleware/LocalizedRouteLocaleHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace CodeZero\LocalizedRoutes\Middleware;
+
+use Closure;
+use \Illuminate\Support\Facades\App;
+
+class LocalizedRouteLocaleHandler
+{
+    /**
+     * Set language for localized route
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $action = $request->route()->getAction();
+
+        if ($action['localized-routes-locale']) {
+            App::setLocale($action['localized-routes-locale']);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
When activated (deactivated by default to be non-breaking) sets the app locale when entering a localized route.

Version suggestion: feature (adds functionality, is non-breaking)