### PR TITLE
Fix L8 cached routes

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,17 +9,31 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 7.2.5, 7.3, 7.4 ]
-        laravel: [ 7.*, 8.* ]
+        php: [ 7.1, 7.2, 7.3, 7.4 ]
+        laravel: [ 5.6.*, 5.7.*, 5.8.*, 6.*, 7.*, 8.* ]
         dependency-version: [ prefer-stable ]
         include:
+          - laravel: 5.6.*
+            testbench: 3.6.*
+          - laravel: 5.7.*
+            testbench: 3.7.*
+          - laravel: 5.8.*
+            testbench: 3.8.*
+          - laravel: 6.*
+            testbench: 4.*
           - laravel: 7.*
             testbench: 5.*
           - laravel: 8.*
             testbench: 6.*
         exclude:
           - laravel: 8.*
-            php: 7.2.5
+            php: 7.1
+          - laravel: 8.*
+            php: 7.2
+          - laravel: 7.*
+            php: 7.1
+          - laravel: 6.*
+            php: 7.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,31 +9,17 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 7.1, 7.2, 7.3, 7.4 ]
-        laravel: [ 5.6.*, 5.7.*, 5.8.*, 6.*, 7.*, 8.* ]
+        php: [ 7.2.5, 7.3, 7.4 ]
+        laravel: [ 7.*, 8.* ]
         dependency-version: [ prefer-stable ]
         include:
-          - laravel: 5.6.*
-            testbench: 3.6.*
-          - laravel: 5.7.*
-            testbench: 3.7.*
-          - laravel: 5.8.*
-            testbench: 3.8.*
-          - laravel: 6.*
-            testbench: 4.*
           - laravel: 7.*
             testbench: 5.*
           - laravel: 8.*
             testbench: 6.*
         exclude:
           - laravel: 8.*
-            php: 7.1
-          - laravel: 8.*
-            php: 7.2
-          - laravel: 7.*
-            php: 7.1
-          - laravel: 6.*
-            php: 7.1
+            php: 7.2.5
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2.5",
         "0.0.0/composer-include-files": "^1.5",
         "codezero/laravel-localizer": "^1.1",
-        "illuminate/support": "^5.6|^6.0|^7.0|^8.0"
+        "illuminate/support": "^7.0|^8.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.3",
-        "orchestra/testbench": "^3.6|^4.0|^5.0|^6.0",
-        "phpunit/phpunit": "^7.0|^8.0|^9.0"
+        "mockery/mockery": "^1.3.1",
+        "orchestra/testbench": "^5.0|^6.0",
+        "phpunit/phpunit": "^8.4|^9.0"
     },
     "scripts": {
         "test": "phpunit"

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.1",
         "0.0.0/composer-include-files": "^1.5",
         "codezero/laravel-localizer": "^1.1",
-        "illuminate/support": "^7.0|^8.0"
+        "illuminate/support": "^5.6|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.3.1",
-        "orchestra/testbench": "^5.0|^6.0",
-        "phpunit/phpunit": "^8.4|^9.0"
+        "mockery/mockery": "^1.0",
+        "orchestra/testbench": "^3.6|^4.0|^5.0|^6.0",
+        "phpunit/phpunit": "^7.0|^8.0|^9.0"
     },
     "scripts": {
         "test": "phpunit"

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -3,7 +3,7 @@
 namespace CodeZero\LocalizedRoutes;
 
 use Illuminate\Http\Request;
-use Illuminate\Routing\RouteCollection;
+use Illuminate\Routing\RouteCollectionInterface;
 use Illuminate\Routing\UrlGenerator as BaseUrlGenerator;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
@@ -18,7 +18,7 @@ class UrlGenerator extends BaseUrlGenerator
      * @param \Illuminate\Http\Request $request
      * @param string $assetRoot
      */
-    public function __construct(RouteCollection $routes, Request $request, $assetRoot = null)
+    public function __construct(RouteCollectionInterface $routes, Request $request, $assetRoot = null)
     {
         parent::__construct($routes, $request, $assetRoot);
     }

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -3,6 +3,7 @@
 namespace CodeZero\LocalizedRoutes;
 
 use Illuminate\Http\Request;
+use Illuminate\Routing\RouteCollection;
 use Illuminate\Routing\RouteCollectionInterface;
 use Illuminate\Routing\UrlGenerator as BaseUrlGenerator;
 use Illuminate\Support\Facades\App;
@@ -18,9 +19,13 @@ class UrlGenerator extends BaseUrlGenerator
      * @param \Illuminate\Http\Request $request
      * @param string $assetRoot
      */
-    public function __construct(RouteCollectionInterface $routes, Request $request, $assetRoot = null)
+    public function __construct($routes, Request $request, $assetRoot = null)
     {
-        parent::__construct($routes, $request, $assetRoot);
+        if ($routes instanceof RouteCollection || (class_exists('Illuminate\Routing\RouteCollectionInterface') && is_subclass_of($routes, 'Illuminate\Routing\RouteCollectionInterface'))) {
+            parent::__construct($routes, $request, $assetRoot);
+        } else {
+            throw new \InvalidArgumentException('The $routes parameter has to be of type RouteCollection or RouteCollectionInterface for L6+.');
+        }        
     }
 
     /**

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -21,11 +21,11 @@ class UrlGenerator extends BaseUrlGenerator
      */
     public function __construct($routes, Request $request, $assetRoot = null)
     {
-        if ($routes instanceof RouteCollection || (class_exists('Illuminate\Routing\RouteCollectionInterface') && is_subclass_of($routes, 'Illuminate\Routing\RouteCollectionInterface'))) {
-            parent::__construct($routes, $request, $assetRoot);
-        } else {
+        if (!$routes instanceof RouteCollection || !(class_exists('Illuminate\Routing\RouteCollectionInterface') && is_subclass_of($routes, 'Illuminate\Routing\RouteCollectionInterface'))) {
             throw new \InvalidArgumentException('The $routes parameter has to be of type RouteCollection or RouteCollectionInterface for L6+.');
-        }        
+        }
+        
+        parent::__construct($routes, $request, $assetRoot);
     }
 
     /**

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -4,7 +4,6 @@ namespace CodeZero\LocalizedRoutes;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\RouteCollection;
-use Illuminate\Routing\RouteCollectionInterface;
 use Illuminate\Routing\UrlGenerator as BaseUrlGenerator;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
@@ -21,7 +20,7 @@ class UrlGenerator extends BaseUrlGenerator
      */
     public function __construct($routes, Request $request, $assetRoot = null)
     {
-        if (!$routes instanceof RouteCollection || !(class_exists('Illuminate\Routing\RouteCollectionInterface') && is_subclass_of($routes, 'Illuminate\Routing\RouteCollectionInterface'))) {
+        if (!$routes instanceof RouteCollection && !(class_exists('Illuminate\Routing\RouteCollectionInterface') && is_subclass_of($routes, 'Illuminate\Routing\RouteCollectionInterface'))) {
             throw new \InvalidArgumentException('The $routes parameter has to be of type RouteCollection or RouteCollectionInterface for L6+.');
         }
         


### PR DESCRIPTION
This will fix the following error when using cached routes without the $namespace member in your RouteServiceProvider:

```
Argument 1 passed to CodeZero\LocalizedRoutes\UrlGenerator::__construct() must be an instance of Illuminate\Routing\RouteCollection, instance of Illuminate\Routing\CompiledRouteCollection given, called in /var/www/vendor/codezero/laravel-localized-routes/src/LocalizedRoutesServiceProvider.php on line 104
```
This is caused by using `php artisan route:cache` as the provided type will be [CompiledRouteCollection](https://laravel.com/api/7.x/Illuminate/Routing/CompiledRouteCollection.html)