### PR TITLE
Fix UrlGenerator class_exists on interface

### DIFF
--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -20,7 +20,7 @@ class UrlGenerator extends BaseUrlGenerator
      */
     public function __construct($routes, Request $request, $assetRoot = null)
     {
-        if (!$routes instanceof RouteCollection && !(class_exists('Illuminate\Routing\RouteCollectionInterface') && is_subclass_of($routes, 'Illuminate\Routing\RouteCollectionInterface'))) {
+        if (!$routes instanceof RouteCollection && !(interface_exists('\Illuminate\Routing\RouteCollectionInterface') && is_subclass_of($routes, '\Illuminate\Routing\RouteCollectionInterface'))) {
             throw new \InvalidArgumentException('The $routes parameter has to be of type RouteCollection or RouteCollectionInterface for L6+.');
         }
         


### PR DESCRIPTION
Sorry for the inconvenience, but class_exists does not work on interfaces ([reference](https://www.php.net/manual/de/function.class-exists.php#refsect1-function.class-exists-changelog)). This should have been obvious, i'm sorry! Though i'm curious how the tests finished ^^