### PR TITLE
Add a route macro for a localized Route::has

### DIFF
--- a/src/LocalizedRoutesServiceProvider.php
+++ b/src/LocalizedRoutesServiceProvider.php
@@ -3,6 +3,7 @@
 namespace CodeZero\LocalizedRoutes;
 
 use CodeZero\LocalizedRoutes\Macros\IsLocalizedMacro;
+use CodeZero\LocalizedRoutes\Macros\LocalizedHasMacro;
 use CodeZero\LocalizedRoutes\Macros\LocalizedUrlMacro;
 use CodeZero\LocalizedRoutes\Macros\UriTranslationMacro;
 use CodeZero\LocalizedRoutes\Macros\LocalizedRoutesMacro;
@@ -49,6 +50,7 @@ class LocalizedRoutesServiceProvider extends ServiceProvider
     protected function registerMacros()
     {
         IsLocalizedMacro::register();
+        LocalizedHasMacro::register();
         LocalizedRoutesMacro::register();
         LocalizedUrlMacro::register();
         UriTranslationMacro::register();

--- a/src/Macros/LocalizedHasMacro.php
+++ b/src/Macros/LocalizedHasMacro.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace CodeZero\LocalizedRoutes\Macros;
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Route;
+
+class LocalizedHasMacro
+{
+    /**
+     * Register the macro.
+     *
+     * @return void
+     */
+    public static function register()
+    {
+        Route::macro('localizedHas', function ($name, $locale = null) {
+            $locale = $locale ?? App::getLocale();
+            if (! $this->routes->hasNamedRoute($locale . ".{$name}")) {
+                return false;
+            }
+
+            return true;
+        });
+    }
+}


### PR DESCRIPTION
This adds a new macro for a version of `Route::has()` which respects localization.
By default it will load the current locale, or one can be passed to it as a second argument.

An alternative implementation, could be that the default checks if the route name exists on the default locale. I.e. pull the default from the config and use that if a locale isn't passed as the second arg.

Then for the use case of 'current locale', one could simply pass `app()->getLocale()`.