### PR TITLE
Attempt to translate full uri + link fixed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ Check out the [Laravel docs](https://laravel.com/docs/urls#signed-urls) for more
 
 ### 🌎 Translate Routes
 
-If you want to translate the segments of your URI's, create a `routes.php` language file for each locale you [configured](#configure-supported-locales):
+If you want to translate the segments of your URI's, create a `routes.php` language file for each locale you [configured](#%EF%B8%8F-supported-locales):
 
 ```
 resources

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - Optionally [detect and set the preferred locale in multiple sources](#%EF%B8%8F-use-localizer-to-detect-and-set-the-locale).
 - Use localized route keys with [route model binding](#-route-model-binding).
 - Allow routes to be [cached](#-cache-routes).
-- Localize [`404` pages](#-localized-404-pages).
+- Localize [`404` pages](#-localized-404-pages-and-redirecting-to-localized-urls).
 
 ## ✅ Requirements
 
@@ -551,7 +551,7 @@ $url = route('posts.show', [$post], true, 'nl'); // /nl/posts/nl-slug
 
 ## 🚴‍ Route Model Binding
 
-If you enable the [middleware](#-use-middleware-to-update-app-locale) included in this package,
+If you enable the [middleware](#%EF%B8%8F-use-middleware-to-update-app-locale) included in this package,
 you can use [Laravel's route model binding](https://laravel.com/docs/routing#route-model-binding)
 to automatically inject models with localized route keys in your controllers.
 

--- a/src/Macros/UriTranslationMacro.php
+++ b/src/Macros/UriTranslationMacro.php
@@ -16,6 +16,12 @@ class UriTranslationMacro
     public static function register()
     {
         Lang::macro('uri', function ($uri, $locale = null) {
+
+            // Attempt to translate full uri.
+            if (!Str::contains($uri, '{') && Lang::has("routes.$uri", $locale)) {
+                return Lang::get("routes.$uri", [], $locale);
+            }
+            
             // Split the URI into a Collection of segments.
             $segments = new Collection(explode('/', trim($uri, '/')));
 


### PR DESCRIPTION
**Example**

**web.php**
`Route::get(Lang::uri('products/glass'), fn() => view(....)->name(....);`

**lang/it/routes.php**
```php
return [
    'glass'          => 'vetro',
    'products'       => 'prodotti',
    'products/glass' => 'prodotti/bicchiere'
];

```

❌ Current result: `'prodotti/vetro'`
✅ Expected result: `'prodotti/bicchiere'`

This change allows me to define a translation for a specific route