### PR TITLE
Add possibility to translate namespaced routes or segments

### DIFF
--- a/src/Macros/UriTranslationMacro.php
+++ b/src/Macros/UriTranslationMacro.php
@@ -16,7 +16,7 @@ class UriTranslationMacro
     public static function register()
     {
         Lang::macro('uri', function ($uri, $locale = null, $namespace = null) {
- 
+
             // Attempt to translate full uri.
             if (!Str::contains($uri, '{') && Lang::has(($namespace ? $namespace.'::' : '')."routes.$uri", $locale)) {
                 return Lang::get(($namespace ? $namespace.'::' : '')."routes.$uri", [], $locale);

--- a/src/Macros/UriTranslationMacro.php
+++ b/src/Macros/UriTranslationMacro.php
@@ -27,7 +27,7 @@ class UriTranslationMacro
 
             // Attempt to translate each segment. If there is no translation
             // for a specific segment, then its original value will be used.
-            $translations = $segments->map(function ($segment) use ($locale) {
+            $translations = $segments->map(function ($segment) use ($locale, $namespace) {
                 $translationKey = ($namespace ? $namespace.'::' : '')."routes.{$segment}";
 
                 // If the segment is not a placeholder and the segment

--- a/src/Macros/UriTranslationMacro.php
+++ b/src/Macros/UriTranslationMacro.php
@@ -15,11 +15,11 @@ class UriTranslationMacro
      */
     public static function register()
     {
-        Lang::macro('uri', function ($uri, $locale = null) {
-
+        Lang::macro('uri', function ($uri, $locale = null, $namespace = null) {
+ 
             // Attempt to translate full uri.
-            if (!Str::contains($uri, '{') && Lang::has("routes.$uri", $locale)) {
-                return Lang::get("routes.$uri", [], $locale);
+            if (!Str::contains($uri, '{') && Lang::has(($namespace ? $namespace.'::' : '')."routes.$uri", $locale)) {
+                return Lang::get(($namespace ? $namespace.'::' : '')."routes.$uri", [], $locale);
             }
             
             // Split the URI into a Collection of segments.
@@ -28,11 +28,11 @@ class UriTranslationMacro
             // Attempt to translate each segment. If there is no translation
             // for a specific segment, then its original value will be used.
             $translations = $segments->map(function ($segment) use ($locale) {
-                $translationKey = "routes.{$segment}";
+                $translationKey = ($namespace ? $namespace.'::' : '')."routes.{$segment}";
 
                 // If the segment is not a placeholder and the segment
                 // has a translation, then update the segment.
-                if ( ! Str::startsWith($segment, '{') && Lang::has($translationKey, $locale)) {
+                if (!Str::startsWith($segment, '{') && Lang::has($translationKey, $locale)) {
                     $segment = Lang::get($translationKey, [], $locale);
                 }
 


### PR DESCRIPTION
Example:

```php
Route::localized(function () {

    Route::get(Lang::uri('about/us', null, 'blog'), AboutController::class.'@index')
        ->name('about.us');

});
```