### PR TITLE
Ability to generate current localized url using two different models with route model binding

### DIFF
--- a/tests/Stubs/ModelBar.php
+++ b/tests/Stubs/ModelBar.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace CodeZero\LocalizedRoutes\Tests\Stubs;
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Database\Eloquent\Model as BaseModel;
+use CodeZero\LocalizedRoutes\ProvidesRouteParameters;
+
+class ModelBar extends BaseModel implements ProvidesRouteParameters
+{
+    protected $guarded = [];
+
+    /**
+     * Get the route parameters for this model.
+     *
+     * @param string|null $locale
+     *
+     * @return array
+     */
+    public function getRouteParameters($locale = null)
+    {
+        return [
+            $this->attributes['slug'][$locale ?: App::getLocale()]
+        ];
+    }
+
+    /**
+     * Fake route model binding (avoid database for test purpose).
+     *
+     * @param int $id
+     * @param string|null $field
+     *
+     * @return mixed
+     */
+    public function resolveRouteBinding($id, $field = null)
+    {
+        return $this;
+    }
+}

--- a/tests/Stubs/ModelFoo.php
+++ b/tests/Stubs/ModelFoo.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace CodeZero\LocalizedRoutes\Tests\Stubs;
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Database\Eloquent\Model as BaseModel;
+use CodeZero\LocalizedRoutes\ProvidesRouteParameters;
+
+class ModelFoo extends BaseModel implements ProvidesRouteParameters
+{
+    protected $guarded = [];
+
+    /**
+     * Get the route parameters for this model.
+     *
+     * @param string|null $locale
+     *
+     * @return array
+     */
+    public function getRouteParameters($locale = null)
+    {
+        return [
+            $this->attributes['slug'][$locale ?: App::getLocale()]
+        ];
+    }
+
+    /**
+     * Fake route model binding (avoid database for test purpose).
+     *
+     * @param int $id
+     * @param string|null $field
+     *
+     * @return mixed
+     */
+    public function resolveRouteBinding($id, $field = null)
+    {
+        return $this;
+    }
+}

--- a/tests/Unit/RouteModelBindingTest.php
+++ b/tests/Unit/RouteModelBindingTest.php
@@ -2,10 +2,10 @@
 
 namespace CodeZero\LocalizedRoutes\Tests\Unit;
 
-use CodeZero\LocalizedRoutes\Tests\Stubs\Model;
-use CodeZero\LocalizedRoutes\Tests\TestCase;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
+use CodeZero\LocalizedRoutes\Tests\TestCase;
+use CodeZero\LocalizedRoutes\Tests\Stubs\Model;
 
 class RouteModelBindingTest extends TestCase
 {


### PR DESCRIPTION
As far as I can tell the main issue was the in the `prepareParameters` method on `LocalizedUrlGenerator` class. It was looking specifically only for the first model.