### PR TITLE
Custom prefixes

### DIFF
--- a/config/localized-routes.php
+++ b/config/localized-routes.php
@@ -68,4 +68,14 @@ return [
      */
     'use_localizer' => false,
 
+    /**
+     * Map application locale to a custom route prefix.
+     *
+     * 'custom_prefixes' => [
+     *   'en' => 'english',
+     *   'nl' => 'dutch',
+     * ]
+     */
+    'custom_prefixes' => [],
+
 ];

--- a/src/Controller/FallbackController.php
+++ b/src/Controller/FallbackController.php
@@ -32,7 +32,7 @@ class FallbackController extends Controller
             }
         }
 
-        return $this->NotFoundResponse();
+        return $this->notFoundResponse();
     }
 
     /**
@@ -54,7 +54,7 @@ class FallbackController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    protected function NotFoundResponse()
+    protected function notFoundResponse()
     {
         $view = Config::get('localized-routes.404_view');
 

--- a/src/LocalizedUrlGenerator.php
+++ b/src/LocalizedUrlGenerator.php
@@ -69,10 +69,13 @@ class LocalizedUrlGenerator
             $urlBuilder->setPath($this->replaceParameters($this->route->uri(), $slugs));
         }
 
+        // Map the locale string to a prefix.
+        $prefix = data_get(Config::get('localized-routes.custom_prefixes'), $locale, $locale);
+
         // If custom domains are not used and it is not a registered,
         // non localized route, update the locale slug in the path.
         if (!$this->hasCustomDomains() && ($this->is404() || $this->isLocalized())) {
-            $urlBuilder->setSlugs($this->updateLocaleInSlugs($urlBuilder->getSlugs(), $locale));
+            $urlBuilder->setSlugs($this->updateLocaleInSlugs($urlBuilder->getSlugs(), $prefix));
         }
 
         if ($domain = $this->getCustomDomain($locale)) {

--- a/src/Macros/LocalizedRoutesMacro.php
+++ b/src/Macros/LocalizedRoutesMacro.php
@@ -54,14 +54,11 @@ class LocalizedRoutesMacro
                 // to register translated route URI's.
                 App::setLocale($locale);
 
-                // Map the locale string to a prefix.
-                $prefix = data_get(Config::get('localized-routes.custom_prefixes'), $locale, $locale);
-
                 // Prepend the locale to the route name
                 // and set a custom attribute so the middleware
                 // can find it to set the correct app locale.
                 $attributes = [
-                    'as' => "{$prefix}.",
+                    'as' => "{$locale}.",
                     'localized-routes-locale' => $locale
                 ];
 
@@ -70,6 +67,9 @@ class LocalizedRoutesMacro
                 if ($domain !== null) {
                     $attributes['domain'] = $domain;
                 }
+
+                // Map the locale string to a prefix.
+                $prefix = data_get(Config::get('localized-routes.custom_prefixes'), $locale, $locale);
 
                 // Prefix the URL unless the locale
                 // is configured to be omitted.

--- a/src/Macros/LocalizedRoutesMacro.php
+++ b/src/Macros/LocalizedRoutesMacro.php
@@ -28,7 +28,7 @@ class LocalizedRoutesMacro
             $setMiddleware = $options['use_locale_middleware']
                                 ?? Config::get('localized-routes.use_locale_middleware', false);
 
-            $notUsingDomains = is_numeric(array_key_first($locales));
+            $notUsingDomains = is_numeric(key($locales));
 
             if ($omitPrefix && $notUsingDomains) {
                 // Move the omitted locale to the end of the array

--- a/src/Macros/LocalizedRoutesMacro.php
+++ b/src/Macros/LocalizedRoutesMacro.php
@@ -54,11 +54,14 @@ class LocalizedRoutesMacro
                 // to register translated route URI's.
                 App::setLocale($locale);
 
+                // Map the locale string to a prefix.
+                $prefix = data_get(Config::get('localized-routes.custom_prefixes'), $locale, $locale);
+
                 // Prepend the locale to the route name
                 // and set a custom attribute so the middleware
                 // can find it to set the correct app locale.
                 $attributes = [
-                    'as' => "{$locale}.",
+                    'as' => "{$prefix}.",
                     'localized-routes-locale' => $locale
                 ];
 
@@ -71,7 +74,7 @@ class LocalizedRoutesMacro
                 // Prefix the URL unless the locale
                 // is configured to be omitted.
                 if ($domain === null && $locale !== $omitPrefix) {
-                    $attributes['prefix'] = $locale;
+                    $attributes['prefix'] = $prefix;
                 }
 
                 if ($setMiddleware) {

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -54,13 +54,16 @@ class UrlGenerator extends BaseUrlGenerator
         // as a prefix for the route name.
         $locale = $locale ?: $currentLocale;
 
+        // Map the locale string to a prefix.
+        $prefix = data_get(Config::get('localized-routes.custom_prefixes'), $locale, $locale);
+
         // Normalize the route name by removing any locale prefix.
         // We will prepend the applicable locale manually.
         $baseName = $this->stripLocaleFromRouteName($name);
 
         // If the route has a name (not just the locale prefix)
         // add the requested locale prefix.
-        $newName = $baseName ? "{$locale}.{$baseName}" : '';
+        $newName = $baseName ? "{$prefix}.{$baseName}" : '';
 
         // If the new localized name does not exist, but the unprefixed route name does,
         // someone might be calling "route($name, [], true, $locale)" on a non localized route.

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -54,16 +54,13 @@ class UrlGenerator extends BaseUrlGenerator
         // as a prefix for the route name.
         $locale = $locale ?: $currentLocale;
 
-        // Map the locale string to a prefix.
-        $prefix = data_get(Config::get('localized-routes.custom_prefixes'), $locale, $locale);
-
         // Normalize the route name by removing any locale prefix.
         // We will prepend the applicable locale manually.
         $baseName = $this->stripLocaleFromRouteName($name);
 
         // If the route has a name (not just the locale prefix)
         // add the requested locale prefix.
-        $newName = $baseName ? "{$prefix}.{$baseName}" : '';
+        $newName = $baseName ? "{$locale}.{$baseName}" : '';
 
         // If the new localized name does not exist, but the unprefixed route name does,
         // someone might be calling "route($name, [], true, $locale)" on a non localized route.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -116,6 +116,18 @@ abstract class TestCase extends  BaseTestCase
     }
 
     /**
+     * Set the custom prefixes config option.
+     *
+     * @param array $prefixes
+     *
+     * @return void
+     */
+    protected function setCustomPrefixes($prefixes)
+    {
+        Config::set('localized-routes.custom_prefixes', $prefixes);
+    }
+
+    /**
      * Fake that we created a routes.php file in 'resources/lang/'
      * for each language with the given translations.
      *

--- a/tests/Unit/Middleware/SetLocaleTest.php
+++ b/tests/Unit/Middleware/SetLocaleTest.php
@@ -216,4 +216,26 @@ class SetLocaleTest extends TestCase
 
         $localizer->shouldHaveReceived('setSupportedLocales')->with(['en', 'nl']);
     }
+
+    /** @test */
+    public function it_sets_the_right_locale_with_custom_prefixes()
+    {
+        $this->setSupportedLocales(['en', 'nl']);
+        $this->setCustomPrefixes(['en' => 'english', 'nl' => 'dutch']);
+        $this->setUseLocaleMiddleware(true);
+
+        Route::localized(function () {
+            Route::get('/', function () {
+                return App::getLocale();
+            });
+        });
+
+        $response = $this->call('GET', '/english');
+        $response->assertOk();
+        $this->assertEquals('en', $response->original);
+
+        $response = $this->call('GET', '/dutch');
+        $response->assertOk();
+        $this->assertEquals('nl', $response->original);
+    }
 }

--- a/tests/Unit/RedirectToLocalizedTest.php
+++ b/tests/Unit/RedirectToLocalizedTest.php
@@ -74,4 +74,33 @@ class RedirectToLocalizedTest extends TestCase
         $this->setAppLocale('en');
         $this->get('missing')->assertNotFound();
     }
+
+    /** @test */
+    public function it_redirects_to_the_localized_url_with_custom_prefixes()
+    {
+        $this->withoutExceptionHandling();
+        $this->setSupportedLocales(['en', 'nl']);
+        $this->setCustomPrefixes(['en' => 'english', 'nl' => 'dutch']);
+        $this->setUseLocaleMiddleware(false);
+        $this->setRedirectToLocalizedUrls(true);
+
+        Route::localized(function () {
+            Route::get('/', function () {});
+            Route::get('about', function () {});
+        });
+
+        Route::fallback(\CodeZero\LocalizedRoutes\Controller\FallbackController::class);
+
+        $this->setAppLocale('en');
+        $this->get('/')->assertRedirect('english');
+        $this->get('english')->assertOk();
+        $this->get('about')->assertRedirect('english/about');
+        $this->get('english/about')->assertOk();
+
+        $this->setAppLocale('nl');
+        $this->get('/')->assertRedirect('dutch');
+        $this->get('dutch')->assertOk();
+        $this->get('about')->assertRedirect('dutch/about');
+        $this->get('dutch/about')->assertOk();
+    }
 }

--- a/tests/Unit/UrlGeneratorTest.php
+++ b/tests/Unit/UrlGeneratorTest.php
@@ -278,12 +278,12 @@ class UrlGeneratorTest extends TestCase
         // Set custom prefixes for all locales except "fr"
         $this->setCustomPrefixes(['en' => 'english', 'nl' => 'dutch']);
 
-        $this->registerRoute('english/route', 'english.route');
-        $this->registerRoute('dutch/route', 'dutch.route');
+        $this->registerRoute('english/route', 'en.route');
+        $this->registerRoute('dutch/route', 'nl.route');
         $this->registerRoute('fr/route', 'fr.route');
 
-        $this->assertEquals(url('english/route'), route('english.route'));
-        $this->assertEquals(url('dutch/route'), route('dutch.route'));
+        $this->assertEquals(url('english/route'), route('en.route'));
+        $this->assertEquals(url('dutch/route'), route('nl.route'));
         $this->assertEquals(url('fr/route'), route('fr.route'));
     }
 

--- a/tests/Unit/UrlGeneratorTest.php
+++ b/tests/Unit/UrlGeneratorTest.php
@@ -270,6 +270,23 @@ class UrlGeneratorTest extends TestCase
         $this->get('en/route')->assertSuccessful();
     }
 
+    /** @test */
+    public function it_maps_locales_with_custom_prefixes()
+    {
+        $this->setSupportedLocales(['en', 'nl', 'fr']);
+
+        // Set custom prefixes for all locales except "fr"
+        $this->setCustomPrefixes(['en' => 'english', 'nl' => 'dutch']);
+
+        $this->registerRoute('english/route', 'english.route');
+        $this->registerRoute('dutch/route', 'dutch.route');
+        $this->registerRoute('fr/route', 'fr.route');
+
+        $this->assertEquals(url('english/route'), route('english.route'));
+        $this->assertEquals(url('dutch/route'), route('dutch.route'));
+        $this->assertEquals(url('fr/route'), route('fr.route'));
+    }
+
     /**
      * Cache registered routes.
      *


### PR DESCRIPTION
Adds backwards compatible support for custom prefixes. This aims to cover one part of #20.

I've used the term "custom prefixes" instead of "slugs" as the latter is used elsewhere in the codebase to reference parts of the path that get localized.

The approach is to preserve the route name prefix as the application locale, and to modify the URL generators to use a custom prefix, if provided.

If custom prefixes are not set, or there is not a custom prefix for any specific locale, the locale string itself is used.