### PR TITLE
WIP - Support Livewire

### DIFF
--- a/src/Middleware/SetLocale.php
+++ b/src/Middleware/SetLocale.php
@@ -3,6 +3,13 @@
 namespace CodeZero\LocalizedRoutes\Middleware;
 
 use Closure;
+use CodeZero\LocalizedRoutes\LocalizedUrlGenerator;
+use CodeZero\LocalizedRoutes\Middleware\Detectors\RouteActionDetector;
+use CodeZero\LocalizedRoutes\Middleware\Detectors\UrlDetector;
+use CodeZero\LocalizedRoutes\RouteHelper;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Route;
 
 class SetLocale
 {
@@ -33,12 +40,55 @@ class SetLocale
      */
     public function handle($request, Closure $next)
     {
+        $originalRequest = $this->useOriginalRequestDuringLivewireRequests($request);
+
         $locale = $this->handler->detect();
 
         if ($locale) {
             $this->handler->store($locale);
         }
 
+        // This is rom the SubstituteBindings middleware, but
+        // it needs to run on the request we created,
+        // after the locale is updated.
+        Route::substituteBindings($originalRequest->route());
+        Route::substituteImplicitBindings($originalRequest->route());
+
         return $next($request);
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return mixed
+     */
+    public function useOriginalRequestDuringLivewireRequests(Request $request)
+    {
+        $url = $request->fullUrl();// Livewire::originalUrl();
+        $originalRequest = Request::create($url);
+
+        $originalRequest->setRouteResolver(function () use ($originalRequest) {
+            return Route::getRoutes()->match($originalRequest);
+        });
+
+        App::bind(LocalizedUrlGenerator::class, function () use ($originalRequest) {
+            return new LocalizedUrlGenerator($originalRequest);
+        });
+
+        App::bind(RouteActionDetector::class, function () use ($originalRequest) {
+            return new RouteActionDetector($originalRequest);
+        });
+
+        App::bind(UrlDetector::class, function () use ($originalRequest) {
+            return new UrlDetector($originalRequest);
+        });
+
+        App::bind(RouteHelper::class, function () use ($originalRequest) {
+            return new RouteHelper($originalRequest);
+        });
+
+        return  $originalRequest;
     }
 }


### PR DESCRIPTION
Attempt to create a fresh Request from the current URL.

If this works we can pass `Livewire::originalUrl()` when the `{locale}/livewire/message/{name}` endpoint is accessed.

Unfortunately `Livewire::originalUrl()` does not include the query string.