### PR TITLE
Prioritizing route parameter over query parameter

### DIFF
--- a/src/LocalizedUrlGenerator.php
+++ b/src/LocalizedUrlGenerator.php
@@ -84,7 +84,7 @@ class LocalizedUrlGenerator
             );
 
             // Merge the route parameters with the query string parameters, if any.
-            $namedRouteParameters = array_merge($routeParameters, $urlBuilder->getQuery());
+            $namedRouteParameters = array_merge($urlBuilder->getQuery(), $routeParameters);
 
             // Generate the URL using the route's name, if possible.
             if ($url = $this->generateNamedRouteURL($locale, $namedRouteParameters, $absolute)) {


### PR DESCRIPTION
We are encountering an issue that arises when a route has a route parameter and the URL query string also contains a parameter with the same name as the route parameter.

This modification ensures that the route parameter value takes precedence over the query parameter with the same name