### PR TITLE
Update LocalizedUrlGenerator.php

### DIFF
--- a/src/LocalizedUrlGenerator.php
+++ b/src/LocalizedUrlGenerator.php
@@ -54,7 +54,7 @@ class LocalizedUrlGenerator
         $requestQueryString = $urlBuilder->getQuery();
 
         $currentDomain = $urlBuilder->getHost();
-        $currentLocaleSlug = $urlBuilder->getSlugs()[0] ?? null;
+        $currentLocaleSlug = $urlBuilder->getSlugs()[0] ?? '';
 
         // Determine in which locale the URL needs to be localized.
         $locale = $locale


### PR DESCRIPTION
Hi @ivanvermeyen,

The following statement in LocalizedUrlGenerator returns either a `string` or a  `null` value:

```php
$currentLocaleSlug = $urlBuilder->getSlugs()[0] ?? null;
```

However, the function signature of `LocaleConfig`, doesn't take a `null`:

```php
public function findLocaleBySlug(string $slug): ?string
```

I encountered this when using the FallbackController, in combination with `redirect_to_localized_urls` when I went to an URL without locale, but with a query parameter in the URL. For example:

`GET http://localhost:1234/?foo=bar`

This crashed the application. With the proposed fix, I get correctly redirected to `http://localhost:1234/nl?foo=bar`, where `nl` is the `fallback_locale`.

Cheers
