### PR TITLE
drop middlewarePriority requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,20 +165,6 @@ protected $middlewareGroups = [
 ];
 ```
 
-You also need to add the middleware to the `$middlewarePriority` array in `app/Http/Kernel.php`.
-If you don't see the `$middlewarePriority` array, you can copy it from the parent class `Illuminate\Foundation\Http\Kernel`.
-
-Make sure to add it after `StartSession` and before `SubstituteBindings` to trigger it in the correct order:
-
-```php
-protected $middlewarePriority = [
-    \Illuminate\Session\Middleware\StartSession::class, // <= after this
-    //...
-    \CodeZero\LocalizedRoutes\Middleware\SetLocale::class,
-    \Illuminate\Routing\Middleware\SubstituteBindings::class, // <= before this
-];
-```
-
 ### Detectors
 
 The middleware runs the following detectors in sequence, until one returns a supported locale:


### PR DESCRIPTION
Pretty trivial, feel free to close - but this simplifies setup and removes the need to keep `$middlewarePriority` in sync with `Illuminate\Foundation\Http\Kernel`. 

I don't think the middlewarePriority is required for most use cases, because if your `web` group  looks like https://github.com/laravel/laravel/blob/10.x/app/Http/Kernel.php#L38, you can just add the package middleware somewhere above `SubstituteBindings` and that will enforce the correct order, without needing to also set the priority. 