### PR TITLE
Prevent global config override

### DIFF
--- a/src/LocalizedRoutesRegistrar.php
+++ b/src/LocalizedRoutesRegistrar.php
@@ -26,9 +26,6 @@ class LocalizedRoutesRegistrar
             return;
         }
 
-        LocaleConfig::setSupportedLocales($locales);
-        LocaleConfig::setOmittedLocale($omittedLocale);
-
         $localeRouteAction = LocaleConfig::getRouteAction();
         $usingDomains = LocaleConfig::hasCustomDomains();
         $usingCustomSlugs = LocaleConfig::hasCustomSlugs();

--- a/tests/Feature/Middleware/SetLocaleTest.php
+++ b/tests/Feature/Middleware/SetLocaleTest.php
@@ -2,6 +2,7 @@
 
 namespace CodeZero\LocalizedRoutes\Tests\Feature\Middleware;
 
+use CodeZero\LocalizedRoutes\Facades\LocaleConfig;
 use CodeZero\LocalizedRoutes\Middleware\SetLocale;
 use CodeZero\LocalizedRoutes\Tests\TestCase;
 use Illuminate\Database\Eloquent\Model;
@@ -298,5 +299,24 @@ class SetLocaleTest extends TestCase
 
         $response = $this->get('de/with-scoped-config');
         $this->assertEquals('de', $response->original);
+    }
+
+    /** @test */
+    public function that_scoped_config_does_not_override_global_config(): void
+    {
+        $this->setSupportedLocales(['en']);
+
+        Route::localized(function () {
+            Route::get('with-scoped-config', function () {
+                return App::getLocale();
+            })->middleware(['web', SetLocale::class]);
+        }, [
+            'supported_locales' => ['en', 'nl'],
+        ]);
+
+        $this->assertEquals(
+            ['en'],
+            LocaleConfig::getSupportedLocales()
+        );
     }
 }


### PR DESCRIPTION
It seems that when setting a scoped option, there are `set*()` calls on the global `LocaleConfig`, which override the global config.

So the following:

```php
// assume originally set config is `'supported_locales' => ['en']`

// add a route with scoped config for English and Dutch
Route::localized(function () {
    Route::get('with-scoped-config', function () {
        return App::getLocale();
    })->middleware(['web', SetLocale::class]);
}, [
    'supported_locales' => ['en', 'nl'],
]);

// add a route without any config
Route::localized(function () {
    Route::get('without-scoped-config', function () {
        return App::getLocale();
    })->middleware(['web', SetLocale::class]);
});
```

would give the second route the same config as the first route.

also, calls afterwards to `LocaleConfig::getSupportedLocales()` and `LocaleConfig::getOmittedLocale()` would retain the value of the last route registration with a corresponding scoped config.

It seems the two lines can simply be removed, but might be worth checking if they had another purpose?

added test that failed before the changes to [LocalizedRoutesRegistrar](https://github.com/codezero-be/laravel-localized-routes/pull/104/files#diff-60a994f5ed9abc80be9890e7903b97caff35eb63ac3f82695eca4cbcd08d23f8L29-L31)