### PR TITLE
Add support Laravel 11 and PHPUnit 10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,28 +8,17 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 8.0, 8.1 ]
-        laravel: [ 8.*, 9.* , 10.*]
+        php: [ 8.1, 8.2, 8.3 ]
+        laravel: [ 10.* , 11.*]
         dependency-version: [ prefer-stable ]
         exclude:
-          - laravel: 10.*
-            php: 8.0
+          - laravel: 11.*
+            php: 8.1
         include:
-          - laravel: 7.*
-            php: 7.2
-            testbench: 5.*
-          - laravel: 7.*
-            php: 8.0
-            testbench: 5.*
-          - laravel: 8.*
-            php: 7.3
-            testbench: 6.*
-          - laravel: 8.*
-            testbench: 6.*
-          - laravel: 9.*
-            testbench: 7.*
           - laravel: 10.*
             testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /phpunit.xml
 composer.lock
 /.phpunit.cache
+/.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /vendor
 /phpunit.xml
 composer.lock
-/.phpunit.result.cache
+/.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Laravel Localized Routes
 
 [![GitHub release](https://img.shields.io/github/release/codezero-be/laravel-localized-routes.svg?style=flat-square)](https://github.com/codezero-be/laravel-localized-routes/releases)
-[![Laravel](https://img.shields.io/badge/laravel-10-red?style=flat-square&logo=laravel&logoColor=white)](https://laravel.com)
+[![Laravel](https://img.shields.io/badge/laravel-11-red?style=flat-square&logo=laravel&logoColor=white)](https://laravel.com)
 [![License](https://img.shields.io/packagist/l/codezero/laravel-localized-routes.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/codezero-be/laravel-localized-routes/run-tests.yml?style=flat-square&logo=github&logoColor=white&label=tests)](https://github.com/codezero-be/laravel-localized-routes/actions)
 [![Code Coverage](https://img.shields.io/codacy/coverage/a5db8a1321664e67900c96eadc575ece/master?style=flat-square)](https://app.codacy.com/gh/codezero-be/laravel-localized-routes)
@@ -53,8 +53,8 @@ A convenient way to set up and use localized routes in a Laravel app.
 
 ## ✅ Requirements
 
-- PHP >= 7.2.5
-- Laravel >= 7.0
+- PHP >= 8.1
+- Laravel >= 10
 - Composer ^2.3 (for [codezero/composer-preload-files](https://github.com/codezero-be/composer-preload-files))
 
 ## ⬆ Upgrade

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,25 @@
 # Upgrade Guide
 
+## Upgrading To 4.0 From 3.x
+
+### ➡ Minimum Requirements Updated
+
+Due to PHP and PHPUnit version constraints with Laravel 11, we dropped support for Laravel 7.x, 8.x and 9.x.
+
+- The minimum PHP version required is now 8.1
+- The minimum Laravel version required is now 10
+
+---
+
+### ➡ Re-register Middleware
+
+Laravel 11 no longer has a `app/Http/Kernel.php` to register middleware.
+This is now handled in `bootstrap/app.php`.
+
+🔸 **Actions Required**
+
+If you use Laravel 11, register the middleware in `bootstrap/app.php` as described in the README.
+
 ## Upgrading To 3.0 From 2.x
 
 This upgrade contains a number of small but breaking changes, as well as a huge internal makeover.

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,17 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
+        "php": "^8.1",
         "codezero/browser-locale": "^3.0",
         "codezero/composer-preload-files": "^1.0",
-        "codezero/laravel-uri-translator": "^1.0",
+        "codezero/laravel-uri-translator": "^2.0",
         "codezero/php-url-builder": "^1.0",
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0"
+        "illuminate/support": "^10.0|^11.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",
-        "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0",
-        "phpunit/phpunit": "^10.0"
+        "orchestra/testbench": "^8.0|^9.0",
+        "phpunit/phpunit": "^10.5"
     },
     "scripts": {
         "test": "phpunit"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "mockery/mockery": "^1.3.3",
         "orchestra/testbench": "^5.0|^6.0|^7.0|^8.0",
-        "phpunit/phpunit": "^8.0|^9.0"
+        "phpunit/phpunit": "^10.0"
     },
     "scripts": {
         "test": "phpunit"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
     <testsuites>
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests/Unit</directory>
@@ -16,15 +16,15 @@
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
     </php>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/tests/Feature/Macros/Route/IsLocalizedMacroTest.php
+++ b/tests/Feature/Macros/Route/IsLocalizedMacroTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Route;
 class IsLocalizedMacroTest extends TestCase
 {
     #[Test]
-    public function it_checks_if_the_current_route_is_localized()
+    public function it_checks_if_the_current_route_is_localized(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -38,7 +38,7 @@ class IsLocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_checks_if_the_current_route_has_a_name_with_any_locale_prefix()
+    public function it_checks_if_the_current_route_has_a_name_with_any_locale_prefix(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -71,7 +71,7 @@ class IsLocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_checks_if_the_current_route_has_a_name_with_a_specific_locale_prefix()
+    public function it_checks_if_the_current_route_has_a_name_with_a_specific_locale_prefix(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -92,7 +92,7 @@ class IsLocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_checks_if_the_current_route_has_a_name_that_is_in_an_array_of_names_with_any_locale_prefix()
+    public function it_checks_if_the_current_route_has_a_name_that_is_in_an_array_of_names_with_any_locale_prefix(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -137,7 +137,7 @@ class IsLocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_checks_if_the_current_route_has_a_name_that_is_in_an_array_of_names_with_a_specific_locale_prefix()
+    public function it_checks_if_the_current_route_has_a_name_that_is_in_an_array_of_names_with_a_specific_locale_prefix(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -182,7 +182,7 @@ class IsLocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_checks_if_the_current_route_has_a_name_with_a_locale_prefix_in_an_array()
+    public function it_checks_if_the_current_route_has_a_name_with_a_locale_prefix_in_an_array(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl', 'fr']);

--- a/tests/Feature/Macros/Route/IsLocalizedMacroTest.php
+++ b/tests/Feature/Macros/Route/IsLocalizedMacroTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
 
-class IsLocalizedMacroTest extends TestCase
+final class IsLocalizedMacroTest extends TestCase
 {
     #[Test]
     public function it_checks_if_the_current_route_is_localized(): void

--- a/tests/Feature/Macros/Route/IsLocalizedMacroTest.php
+++ b/tests/Feature/Macros/Route/IsLocalizedMacroTest.php
@@ -2,12 +2,13 @@
 
 namespace CodeZero\LocalizedRoutes\Tests\Feature\Macros\Route;
 
+use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
 
 class IsLocalizedMacroTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_checks_if_the_current_route_is_localized()
     {
         $this->withoutExceptionHandling();
@@ -36,7 +37,7 @@ class IsLocalizedMacroTest extends TestCase
         $this->assertEquals('false', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_checks_if_the_current_route_has_a_name_with_any_locale_prefix()
     {
         $this->withoutExceptionHandling();
@@ -69,7 +70,7 @@ class IsLocalizedMacroTest extends TestCase
         $this->assertEquals('false', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_checks_if_the_current_route_has_a_name_with_a_specific_locale_prefix()
     {
         $this->withoutExceptionHandling();
@@ -90,7 +91,7 @@ class IsLocalizedMacroTest extends TestCase
         $this->assertEquals('false', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_checks_if_the_current_route_has_a_name_that_is_in_an_array_of_names_with_any_locale_prefix()
     {
         $this->withoutExceptionHandling();
@@ -135,7 +136,7 @@ class IsLocalizedMacroTest extends TestCase
         $this->assertEquals('false', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_checks_if_the_current_route_has_a_name_that_is_in_an_array_of_names_with_a_specific_locale_prefix()
     {
         $this->withoutExceptionHandling();
@@ -180,7 +181,7 @@ class IsLocalizedMacroTest extends TestCase
         $this->assertEquals('false', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_checks_if_the_current_route_has_a_name_with_a_locale_prefix_in_an_array()
     {
         $this->withoutExceptionHandling();

--- a/tests/Feature/Macros/Route/LocalizedMacroTest.php
+++ b/tests/Feature/Macros/Route/LocalizedMacroTest.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Route;
 class LocalizedMacroTest extends TestCase
 {
     #[Test]
-    public function it_registers_a_route_for_each_locale()
+    public function it_registers_a_route_for_each_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
 
@@ -37,7 +37,7 @@ class LocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_registers_a_root_route_for_each_locale()
+    public function it_registers_a_root_route_for_each_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
 
@@ -60,7 +60,7 @@ class LocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_registers_a_url_without_prefix_for_a_configured_main_locale()
+    public function it_registers_a_url_without_prefix_for_a_configured_main_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setOmittedLocale('en');
@@ -84,7 +84,7 @@ class LocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_registers_routes_in_the_correct_order_without_prefix_for_a_configured_main_locale()
+    public function it_registers_routes_in_the_correct_order_without_prefix_for_a_configured_main_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setOmittedLocale('en');
@@ -101,7 +101,7 @@ class LocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_maps_a_custom_slug_to_each_locale()
+    public function it_maps_a_custom_slug_to_each_locale(): void
     {
         $this->setSupportedLocales([
             'en' => 'english',
@@ -125,7 +125,7 @@ class LocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_registers_routes_in_the_correct_order_without_prefix_for_a_configured_main_locale_with_custom_slugs()
+    public function it_registers_routes_in_the_correct_order_without_prefix_for_a_configured_main_locale_with_custom_slugs(): void
     {
         $this->setSupportedLocales([
             'en' => 'english',
@@ -145,7 +145,7 @@ class LocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_maps_a_custom_domain_to_each_locale()
+    public function it_maps_a_custom_domain_to_each_locale(): void
     {
         $this->setSupportedLocales([
             'en' => 'english-domain.com',
@@ -171,7 +171,7 @@ class LocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_registers_routes_in_the_correct_order_without_prefix_for_a_configured_main_locale_with_domains()
+    public function it_registers_routes_in_the_correct_order_without_prefix_for_a_configured_main_locale_with_domains(): void
     {
         $this->setSupportedLocales([
             'en' => 'english-domain.com',
@@ -210,7 +210,7 @@ class LocalizedMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_uses_scoped_config_options()
+    public function it_uses_scoped_config_options(): void
     {
         $this->setSupportedLocales(['en']);
         $this->setOmittedLocale(null);

--- a/tests/Feature/Macros/Route/LocalizedMacroTest.php
+++ b/tests/Feature/Macros/Route/LocalizedMacroTest.php
@@ -7,7 +7,7 @@ use CodeZero\LocalizedRoutes\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 
-class LocalizedMacroTest extends TestCase
+final class LocalizedMacroTest extends TestCase
 {
     #[Test]
     public function it_registers_a_route_for_each_locale(): void

--- a/tests/Feature/Macros/Route/LocalizedMacroTest.php
+++ b/tests/Feature/Macros/Route/LocalizedMacroTest.php
@@ -2,13 +2,14 @@
 
 namespace CodeZero\LocalizedRoutes\Tests\Feature\Macros\Route;
 
+use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 
 class LocalizedMacroTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_registers_a_route_for_each_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -35,7 +36,7 @@ class LocalizedMacroTest extends TestCase
         $this->assertContains('nl/route', $uris);
     }
 
-    /** @test */
+    #[Test]
     public function it_registers_a_root_route_for_each_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -58,7 +59,7 @@ class LocalizedMacroTest extends TestCase
         $this->assertContains('nl', $uris);
     }
 
-    /** @test */
+    #[Test]
     public function it_registers_a_url_without_prefix_for_a_configured_main_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -82,7 +83,7 @@ class LocalizedMacroTest extends TestCase
         $this->assertContains('nl/about', $uris);
     }
 
-    /** @test */
+    #[Test]
     public function it_registers_routes_in_the_correct_order_without_prefix_for_a_configured_main_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -99,7 +100,7 @@ class LocalizedMacroTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_maps_a_custom_slug_to_each_locale()
     {
         $this->setSupportedLocales([
@@ -123,7 +124,7 @@ class LocalizedMacroTest extends TestCase
         $this->assertEquals('dutch', $route->uri);
     }
 
-    /** @test */
+    #[Test]
     public function it_registers_routes_in_the_correct_order_without_prefix_for_a_configured_main_locale_with_custom_slugs()
     {
         $this->setSupportedLocales([
@@ -143,7 +144,7 @@ class LocalizedMacroTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_maps_a_custom_domain_to_each_locale()
     {
         $this->setSupportedLocales([
@@ -169,7 +170,7 @@ class LocalizedMacroTest extends TestCase
         $this->assertEquals('/', $route->uri);
     }
 
-    /** @test */
+    #[Test]
     public function it_registers_routes_in_the_correct_order_without_prefix_for_a_configured_main_locale_with_domains()
     {
         $this->setSupportedLocales([
@@ -208,7 +209,7 @@ class LocalizedMacroTest extends TestCase
         $this->assertEquals('{slug}', $route->uri);
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_scoped_config_options()
     {
         $this->setSupportedLocales(['en']);

--- a/tests/Feature/Macros/Route/LocalizedUrlMacroTest.php
+++ b/tests/Feature/Macros/Route/LocalizedUrlMacroTest.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Facades\View;
 class LocalizedUrlMacroTest extends TestCase
 {
     #[Test]
-    public function it_generates_urls_with_default_localized_route_keys_for_the_current_route_using_route_model_binding()
+    public function it_generates_urls_with_default_localized_route_keys_for_the_current_route_using_route_model_binding(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -53,7 +53,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_urls_for_the_current_route_with_different_models_using_route_model_binding()
+    public function it_generates_urls_for_the_current_route_with_different_models_using_route_model_binding(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -95,7 +95,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_urls_with_custom_localized_route_keys_for_the_current_route_using_route_model_binding()
+    public function it_generates_urls_with_custom_localized_route_keys_for_the_current_route_using_route_model_binding(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -129,7 +129,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function you_can_implement_an_interface_and_let_your_model_return_custom_parameters_with_route_model_binding()
+    public function you_can_implement_an_interface_and_let_your_model_return_custom_parameters_with_route_model_binding(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -164,7 +164,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_cannot_guess_a_localized_route_key_without_route_model_binding()
+    public function it_cannot_guess_a_localized_route_key_without_route_model_binding(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -198,7 +198,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function you_can_pass_it_a_model_with_a_localized_route_key_without_route_model_binding()
+    public function you_can_pass_it_a_model_with_a_localized_route_key_without_route_model_binding(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -232,7 +232,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function you_can_pass_it_a_closure_that_returns_the_parameters_without_route_model_binding()
+    public function you_can_pass_it_a_closure_that_returns_the_parameters_without_route_model_binding(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -271,7 +271,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_handles_unnamed_non_localized_routes()
+    public function it_handles_unnamed_non_localized_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -309,7 +309,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_handles_unnamed_localized_routes()
+    public function it_handles_unnamed_localized_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -349,7 +349,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_the_current_url_for_existing_non_localized_routes()
+    public function it_returns_the_current_url_for_existing_non_localized_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -372,7 +372,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_the_url_for_existing_unnamed_localized_routes_using_custom_slugs()
+    public function it_returns_the_url_for_existing_unnamed_localized_routes_using_custom_slugs(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales([
@@ -401,7 +401,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_the_url_for_existing_named_localized_routes_using_custom_slugs()
+    public function it_returns_the_url_for_existing_named_localized_routes_using_custom_slugs(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales([
@@ -430,7 +430,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_the_url_for_existing_unnamed_localized_routes_using_domains()
+    public function it_returns_the_url_for_existing_unnamed_localized_routes_using_domains(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales([
@@ -460,7 +460,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_the_url_for_existing_named_localized_routes_using_domains()
+    public function it_returns_the_url_for_existing_named_localized_routes_using_domains(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales([
@@ -490,7 +490,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function the_macro_does_not_blow_up_on_a_default_404_error()
+    public function the_macro_does_not_blow_up_on_a_default_404_error(): void
     {
         // Although a default 404 has no Route::current() and is no real View, the composer still triggers.
         // Custom 404 views that trigger the macro still don't have a Route::current().
@@ -504,7 +504,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function a_404_receives_the_correct_localized_url_from_a_view_composer()
+    public function a_404_receives_the_correct_localized_url_from_a_view_composer(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -521,7 +521,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function a_404_is_not_localized_when_triggered_by_a_non_existing_route()
+    public function a_404_is_not_localized_when_triggered_by_a_non_existing_route(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -534,7 +534,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function a_404_is_localized_when_a_registered_route_throws_a_not_found_exception()
+    public function a_404_is_localized_when_a_registered_route_throws_a_not_found_exception(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -553,7 +553,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function a_404_is_localized_when_a_registered_route_throws_a_model_not_found_exception()
+    public function a_404_is_localized_when_a_registered_route_throws_a_model_not_found_exception(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -572,7 +572,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function a_fallback_route_is_not_triggered_when_a_registered_route_throws_a_not_found_exception()
+    public function a_fallback_route_is_not_triggered_when_a_registered_route_throws_a_not_found_exception(): void
     {
         Route::get('abort', function () {
             return abort(404);
@@ -589,7 +589,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function a_fallback_route_is_not_triggered_when_a_registered_route_throws_a_model_not_found_exception()
+    public function a_fallback_route_is_not_triggered_when_a_registered_route_throws_a_model_not_found_exception(): void
     {
         Route::get('route/{model}', function ($model) {
             throw new ModelNotFoundException();
@@ -606,7 +606,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_a_localized_url_for_a_localized_fallback_route()
+    public function it_returns_a_localized_url_for_a_localized_fallback_route(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -632,7 +632,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_a_localized_url_for_a_non_localized_fallback_route_if_the_url_contains_a_supported_locale()
+    public function it_returns_a_localized_url_for_a_non_localized_fallback_route_if_the_url_contains_a_supported_locale(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -656,7 +656,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_a_localized_url_for_a_non_localized_fallback_route_if_the_url_does_not_contain_a_supported_locale()
+    public function it_returns_a_localized_url_for_a_non_localized_fallback_route_if_the_url_does_not_contain_a_supported_locale(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -680,7 +680,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_a_localized_url_for_a_non_localized_fallback_route_when_omitting_the_main_locale()
+    public function it_returns_a_localized_url_for_a_non_localized_fallback_route_when_omitting_the_main_locale(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -705,7 +705,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_a_localized_url_for_a_non_localized_fallback_route_when_using_custom_domains()
+    public function it_returns_a_localized_url_for_a_non_localized_fallback_route_when_using_custom_domains(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales([
@@ -732,7 +732,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_non_absolute_urls_for_existing_routes()
+    public function it_generates_non_absolute_urls_for_existing_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -756,7 +756,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_non_absolute_urls_for_non_existing_routes()
+    public function it_generates_non_absolute_urls_for_non_existing_routes(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -773,7 +773,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_a_url_with_query_string_for_existing_non_localized_unnamed_routes()
+    public function it_returns_a_url_with_query_string_for_existing_non_localized_unnamed_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -796,7 +796,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_a_url_with_query_string_for_existing_localized_unnamed_routes()
+    public function it_returns_a_url_with_query_string_for_existing_localized_unnamed_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -822,7 +822,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_a_url_with_query_string_for_existing_non_localized_named_routes()
+    public function it_returns_a_url_with_query_string_for_existing_non_localized_named_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -845,7 +845,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_a_url_with_query_string_for_existing_localized_named_routes()
+    public function it_returns_a_url_with_query_string_for_existing_localized_named_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -871,7 +871,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_a_url_without_query_string_for_existing_localized_named_routes()
+    public function it_returns_a_url_without_query_string_for_existing_localized_named_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -897,7 +897,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_accepts_query_string_parameters_using_named_routes()
+    public function it_accepts_query_string_parameters_using_named_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -920,7 +920,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_ignores_query_string_parameters_using_named_routes()
+    public function it_ignores_query_string_parameters_using_named_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -943,7 +943,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_accepts_query_string_parameters_using_unnamed_routes()
+    public function it_accepts_query_string_parameters_using_unnamed_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -966,7 +966,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_ignores_query_string_parameters_using_unnamed_routes()
+    public function it_ignores_query_string_parameters_using_unnamed_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -989,7 +989,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_prefers_route_parameters_before_query_string_parameters_with_the_same_name_in_unnamed_routes()
+    public function it_prefers_route_parameters_before_query_string_parameters_with_the_same_name_in_unnamed_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -1023,7 +1023,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_prefers_route_parameters_before_query_string_parameters_with_the_same_name_in_named_routes()
+    public function it_prefers_route_parameters_before_query_string_parameters_with_the_same_name_in_named_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -1057,7 +1057,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_allows_optional_parameters_with_named_routes()
+    public function it_allows_optional_parameters_with_named_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -1080,7 +1080,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_allows_optional_parameters_with_unnamed_routes()
+    public function it_allows_optional_parameters_with_unnamed_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -1103,7 +1103,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_handles_capitalized_parameter_names()
+    public function it_handles_capitalized_parameter_names(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -1126,7 +1126,7 @@ class LocalizedUrlMacroTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_a_url_with_translated_slugs_for_named_routes()
+    public function it_returns_a_url_with_translated_slugs_for_named_routes(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);

--- a/tests/Feature/Macros/Route/LocalizedUrlMacroTest.php
+++ b/tests/Feature/Macros/Route/LocalizedUrlMacroTest.php
@@ -2,6 +2,7 @@
 
 namespace CodeZero\LocalizedRoutes\Tests\Feature\Macros\Route;
 
+use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\Middleware\SetLocale;
 use CodeZero\LocalizedRoutes\Tests\Stubs\Models\ModelOneWithRouteBinding;
 use CodeZero\LocalizedRoutes\Tests\Stubs\Models\ModelTwoWithRouteBinding;
@@ -17,7 +18,7 @@ use Illuminate\Support\Facades\View;
 
 class LocalizedUrlMacroTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_generates_urls_with_default_localized_route_keys_for_the_current_route_using_route_model_binding()
     {
         $this->withoutExceptionHandling();
@@ -51,7 +52,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_urls_for_the_current_route_with_different_models_using_route_model_binding()
     {
         $this->withoutExceptionHandling();
@@ -93,7 +94,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_urls_with_custom_localized_route_keys_for_the_current_route_using_route_model_binding()
     {
         $this->withoutExceptionHandling();
@@ -127,7 +128,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function you_can_implement_an_interface_and_let_your_model_return_custom_parameters_with_route_model_binding()
     {
         $this->withoutExceptionHandling();
@@ -162,7 +163,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_guess_a_localized_route_key_without_route_model_binding()
     {
         $this->withoutExceptionHandling();
@@ -196,7 +197,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function you_can_pass_it_a_model_with_a_localized_route_key_without_route_model_binding()
     {
         $this->withoutExceptionHandling();
@@ -230,7 +231,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function you_can_pass_it_a_closure_that_returns_the_parameters_without_route_model_binding()
     {
         $this->withoutExceptionHandling();
@@ -269,7 +270,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_unnamed_non_localized_routes()
     {
         $this->withoutExceptionHandling();
@@ -307,7 +308,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_unnamed_localized_routes()
     {
         $this->withoutExceptionHandling();
@@ -347,7 +348,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_the_current_url_for_existing_non_localized_routes()
     {
         $this->withoutExceptionHandling();
@@ -370,7 +371,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_the_url_for_existing_unnamed_localized_routes_using_custom_slugs()
     {
         $this->withoutExceptionHandling();
@@ -399,7 +400,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_the_url_for_existing_named_localized_routes_using_custom_slugs()
     {
         $this->withoutExceptionHandling();
@@ -428,7 +429,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_the_url_for_existing_unnamed_localized_routes_using_domains()
     {
         $this->withoutExceptionHandling();
@@ -458,7 +459,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_the_url_for_existing_named_localized_routes_using_domains()
     {
         $this->withoutExceptionHandling();
@@ -488,7 +489,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function the_macro_does_not_blow_up_on_a_default_404_error()
     {
         // Although a default 404 has no Route::current() and is no real View, the composer still triggers.
@@ -502,7 +503,7 @@ class LocalizedUrlMacroTest extends TestCase
         $response->assertResponseHasNoView();
     }
 
-    /** @test */
+    #[Test]
     public function a_404_receives_the_correct_localized_url_from_a_view_composer()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -519,7 +520,7 @@ class LocalizedUrlMacroTest extends TestCase
         $this->assertEquals(URL::to('/nl/route/does/not/exist'), trim($response->original));
     }
 
-    /** @test */
+    #[Test]
     public function a_404_is_not_localized_when_triggered_by_a_non_existing_route()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -532,7 +533,7 @@ class LocalizedUrlMacroTest extends TestCase
         $this->assertEquals('en', trim($response->original));
     }
 
-    /** @test */
+    #[Test]
     public function a_404_is_localized_when_a_registered_route_throws_a_not_found_exception()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -551,7 +552,7 @@ class LocalizedUrlMacroTest extends TestCase
         $this->assertEquals('nl', trim($response->original));
     }
 
-    /** @test */
+    #[Test]
     public function a_404_is_localized_when_a_registered_route_throws_a_model_not_found_exception()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -570,7 +571,7 @@ class LocalizedUrlMacroTest extends TestCase
         $this->assertEquals('nl', trim($response->original));
     }
 
-    /** @test */
+    #[Test]
     public function a_fallback_route_is_not_triggered_when_a_registered_route_throws_a_not_found_exception()
     {
         Route::get('abort', function () {
@@ -587,7 +588,7 @@ class LocalizedUrlMacroTest extends TestCase
         $this->assertNotEquals('fallback', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function a_fallback_route_is_not_triggered_when_a_registered_route_throws_a_model_not_found_exception()
     {
         Route::get('route/{model}', function ($model) {
@@ -604,7 +605,7 @@ class LocalizedUrlMacroTest extends TestCase
         $this->assertNotEquals('fallback', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_localized_url_for_a_localized_fallback_route()
     {
         $this->withoutExceptionHandling();
@@ -630,7 +631,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_localized_url_for_a_non_localized_fallback_route_if_the_url_contains_a_supported_locale()
     {
         $this->withoutExceptionHandling();
@@ -654,7 +655,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_localized_url_for_a_non_localized_fallback_route_if_the_url_does_not_contain_a_supported_locale()
     {
         $this->withoutExceptionHandling();
@@ -678,7 +679,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_localized_url_for_a_non_localized_fallback_route_when_omitting_the_main_locale()
     {
         $this->withoutExceptionHandling();
@@ -703,7 +704,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_localized_url_for_a_non_localized_fallback_route_when_using_custom_domains()
     {
         $this->withoutExceptionHandling();
@@ -730,7 +731,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_non_absolute_urls_for_existing_routes()
     {
         $this->withoutExceptionHandling();
@@ -754,7 +755,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_non_absolute_urls_for_non_existing_routes()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -771,7 +772,7 @@ class LocalizedUrlMacroTest extends TestCase
         $this->assertEquals('/en/route/does/not/exist', trim($response->original));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_url_with_query_string_for_existing_non_localized_unnamed_routes()
     {
         $this->withoutExceptionHandling();
@@ -794,7 +795,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_url_with_query_string_for_existing_localized_unnamed_routes()
     {
         $this->withoutExceptionHandling();
@@ -820,7 +821,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_url_with_query_string_for_existing_non_localized_named_routes()
     {
         $this->withoutExceptionHandling();
@@ -843,7 +844,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_url_with_query_string_for_existing_localized_named_routes()
     {
         $this->withoutExceptionHandling();
@@ -869,7 +870,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_url_without_query_string_for_existing_localized_named_routes()
     {
         $this->withoutExceptionHandling();
@@ -895,7 +896,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_accepts_query_string_parameters_using_named_routes()
     {
         $this->withoutExceptionHandling();
@@ -918,7 +919,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_ignores_query_string_parameters_using_named_routes()
     {
         $this->withoutExceptionHandling();
@@ -941,7 +942,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_accepts_query_string_parameters_using_unnamed_routes()
     {
         $this->withoutExceptionHandling();
@@ -964,7 +965,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_ignores_query_string_parameters_using_unnamed_routes()
     {
         $this->withoutExceptionHandling();
@@ -987,7 +988,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_prefers_route_parameters_before_query_string_parameters_with_the_same_name_in_unnamed_routes()
     {
         $this->withoutExceptionHandling();
@@ -1021,7 +1022,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_prefers_route_parameters_before_query_string_parameters_with_the_same_name_in_named_routes()
     {
         $this->withoutExceptionHandling();
@@ -1055,7 +1056,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_allows_optional_parameters_with_named_routes()
     {
         $this->withoutExceptionHandling();
@@ -1078,7 +1079,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_allows_optional_parameters_with_unnamed_routes()
     {
         $this->withoutExceptionHandling();
@@ -1101,7 +1102,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_capitalized_parameter_names()
     {
         $this->withoutExceptionHandling();
@@ -1124,7 +1125,7 @@ class LocalizedUrlMacroTest extends TestCase
         ], $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_url_with_translated_slugs_for_named_routes()
     {
         $this->withoutExceptionHandling();

--- a/tests/Feature/Macros/Route/LocalizedUrlMacroTest.php
+++ b/tests/Feature/Macros/Route/LocalizedUrlMacroTest.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\View;
 
-class LocalizedUrlMacroTest extends TestCase
+final class LocalizedUrlMacroTest extends TestCase
 {
     #[Test]
     public function it_generates_urls_with_default_localized_route_keys_for_the_current_route_using_route_model_binding(): void

--- a/tests/Feature/Middleware/SetLocaleTest.php
+++ b/tests/Feature/Middleware/SetLocaleTest.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Route;
 class SetLocaleTest extends TestCase
 {
     #[Test]
-    public function it_looks_for_a_locale_in_a_custom_route_action()
+    public function it_looks_for_a_locale_in_a_custom_route_action(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -36,7 +36,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function it_looks_for_a_locale_in_the_url()
+    public function it_looks_for_a_locale_in_the_url(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -53,7 +53,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function it_looks_for_custom_slugs()
+    public function it_looks_for_custom_slugs(): void
     {
         $this->setSupportedLocales([
             'en' => 'english',
@@ -73,7 +73,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function it_looks_for_custom_domains()
+    public function it_looks_for_custom_domains(): void
     {
         $this->setSupportedLocales([
             'en' => 'english.test',
@@ -95,7 +95,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function it_checks_for_a_configured_omitted_locale()
+    public function it_checks_for_a_configured_omitted_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -114,7 +114,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function it_looks_for_a_locale_on_the_authenticated_user()
+    public function it_looks_for_a_locale_on_the_authenticated_user(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -135,7 +135,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function it_will_bypass_missing_attribute_exception_if_the_locale_attribute_is_missing_on_the_user_model()
+    public function it_will_bypass_missing_attribute_exception_if_the_locale_attribute_is_missing_on_the_user_model(): void
     {
         $this->skipTestIfLaravelVersionIsLowerThan('9.35.0');
 
@@ -158,7 +158,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function it_looks_for_a_locale_in_the_session()
+    public function it_looks_for_a_locale_in_the_session(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -177,7 +177,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function it_looks_for_a_locale_in_a_cookie()
+    public function it_looks_for_a_locale_in_a_cookie(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -197,7 +197,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function it_looks_for_a_locale_in_the_browser()
+    public function it_looks_for_a_locale_in_the_browser(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -216,7 +216,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_the_best_match_when_a_browser_locale_is_used()
+    public function it_returns_the_best_match_when_a_browser_locale_is_used(): void
     {
         $this->setSupportedLocales(['en', 'nl', 'fr']);
         $this->setAppLocale('en');
@@ -235,7 +235,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function it_looks_for_the_current_app_locale()
+    public function it_looks_for_the_current_app_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('nl');
@@ -252,7 +252,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function trusted_detectors_ignore_supported_locales_and_may_set_any_locale()
+    public function trusted_detectors_ignore_supported_locales_and_may_set_any_locale(): void
     {
         $this->setSupportedLocales(['en']);
         $this->setAppLocale('en');
@@ -277,7 +277,7 @@ class SetLocaleTest extends TestCase
     }
 
     #[Test]
-    public function it_sets_the_locale_of_routes_with_scoped_config()
+    public function it_sets_the_locale_of_routes_with_scoped_config(): void
     {
         $this->setSupportedLocales(['en']);
         $this->setAppLocale('en');

--- a/tests/Feature/Middleware/SetLocaleTest.php
+++ b/tests/Feature/Middleware/SetLocaleTest.php
@@ -2,6 +2,7 @@
 
 namespace CodeZero\LocalizedRoutes\Tests\Feature\Middleware;
 
+use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\Facades\LocaleConfig;
 use CodeZero\LocalizedRoutes\Middleware\SetLocale;
 use CodeZero\LocalizedRoutes\Tests\TestCase;
@@ -13,7 +14,7 @@ use Illuminate\Support\Facades\Route;
 
 class SetLocaleTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_looks_for_a_locale_in_a_custom_route_action()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -34,7 +35,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('nl', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_looks_for_a_locale_in_the_url()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -51,7 +52,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('nl', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_looks_for_custom_slugs()
     {
         $this->setSupportedLocales([
@@ -71,7 +72,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('nl', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_looks_for_custom_domains()
     {
         $this->setSupportedLocales([
@@ -93,7 +94,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('nl', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_checks_for_a_configured_omitted_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -112,7 +113,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('nl', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_looks_for_a_locale_on_the_authenticated_user()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -133,7 +134,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('nl', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_will_bypass_missing_attribute_exception_if_the_locale_attribute_is_missing_on_the_user_model()
     {
         $this->skipTestIfLaravelVersionIsLowerThan('9.35.0');
@@ -156,7 +157,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('en', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_looks_for_a_locale_in_the_session()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -175,7 +176,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('nl', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_looks_for_a_locale_in_a_cookie()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -195,7 +196,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('nl', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_looks_for_a_locale_in_the_browser()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -214,7 +215,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('nl', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_the_best_match_when_a_browser_locale_is_used()
     {
         $this->setSupportedLocales(['en', 'nl', 'fr']);
@@ -233,7 +234,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('nl', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_looks_for_the_current_app_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -250,7 +251,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('nl', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function trusted_detectors_ignore_supported_locales_and_may_set_any_locale()
     {
         $this->setSupportedLocales(['en']);
@@ -275,7 +276,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('nl', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_the_locale_of_routes_with_scoped_config()
     {
         $this->setSupportedLocales(['en']);
@@ -301,7 +302,7 @@ class SetLocaleTest extends TestCase
         $this->assertEquals('de', $response->original);
     }
 
-    /** @test */
+    #[Test]
     public function that_scoped_config_does_not_override_global_config(): void
     {
         $this->setSupportedLocales(['en']);

--- a/tests/Feature/Middleware/SetLocaleTest.php
+++ b/tests/Feature/Middleware/SetLocaleTest.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 
-class SetLocaleTest extends TestCase
+final class SetLocaleTest extends TestCase
 {
     #[Test]
     public function it_looks_for_a_locale_in_a_custom_route_action(): void

--- a/tests/Feature/RedirectToLocalizedTest.php
+++ b/tests/Feature/RedirectToLocalizedTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Route;
 class RedirectToLocalizedTest extends TestCase
 {
     #[Test]
-    public function it_redirects_to_the_localized_url()
+    public function it_redirects_to_the_localized_url(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -36,7 +36,7 @@ class RedirectToLocalizedTest extends TestCase
     }
 
     #[Test]
-    public function it_redirects_when_default_locale_slug_is_omitted()
+    public function it_redirects_when_default_locale_slug_is_omitted(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en', 'nl']);
@@ -62,7 +62,7 @@ class RedirectToLocalizedTest extends TestCase
     }
 
     #[Test]
-    public function it_throws_404_and_does_not_redirect_if_no_localized_route_is_registered()
+    public function it_throws_404_and_does_not_redirect_if_no_localized_route_is_registered(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setRedirectToLocalizedUrls(true);
@@ -74,7 +74,7 @@ class RedirectToLocalizedTest extends TestCase
     }
 
     #[Test]
-    public function it_redirects_to_the_localized_url_with_custom_slugs()
+    public function it_redirects_to_the_localized_url_with_custom_slugs(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales([

--- a/tests/Feature/RedirectToLocalizedTest.php
+++ b/tests/Feature/RedirectToLocalizedTest.php
@@ -2,12 +2,13 @@
 
 namespace CodeZero\LocalizedRoutes\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
 
 class RedirectToLocalizedTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_redirects_to_the_localized_url()
     {
         $this->withoutExceptionHandling();
@@ -34,7 +35,7 @@ class RedirectToLocalizedTest extends TestCase
         $this->get('nl/about')->assertOk();
     }
 
-    /** @test */
+    #[Test]
     public function it_redirects_when_default_locale_slug_is_omitted()
     {
         $this->withoutExceptionHandling();
@@ -60,7 +61,7 @@ class RedirectToLocalizedTest extends TestCase
         $this->get('nl/about')->assertOk();
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_404_and_does_not_redirect_if_no_localized_route_is_registered()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -72,7 +73,7 @@ class RedirectToLocalizedTest extends TestCase
         $this->get('missing')->assertNotFound();
     }
 
-    /** @test */
+    #[Test]
     public function it_redirects_to_the_localized_url_with_custom_slugs()
     {
         $this->withoutExceptionHandling();

--- a/tests/Feature/RedirectToLocalizedTest.php
+++ b/tests/Feature/RedirectToLocalizedTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
 
-class RedirectToLocalizedTest extends TestCase
+final class RedirectToLocalizedTest extends TestCase
 {
     #[Test]
     public function it_redirects_to_the_localized_url(): void

--- a/tests/Feature/RouteModelBindingTest.php
+++ b/tests/Feature/RouteModelBindingTest.php
@@ -2,6 +2,7 @@
 
 namespace CodeZero\LocalizedRoutes\Tests\Feature;
 
+use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\Middleware\SetLocale;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
@@ -10,7 +11,7 @@ use CodeZero\LocalizedRoutes\Tests\Stubs\Models\ModelOneWithRouteBinding;
 
 class RouteModelBindingTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_loads_a_route_with_a_localized_route_key_based_on_the_active_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -44,7 +45,7 @@ class RouteModelBindingTest extends TestCase
         $this->get('en/test/nl-slug')->assertNotFound();
     }
 
-    /** @test */
+    #[Test]
     public function it_loads_a_route_with_a_custom_localized_route_key_based_on_the_active_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -78,7 +79,7 @@ class RouteModelBindingTest extends TestCase
         $this->get('en/test/nl-slug')->assertNotFound();
     }
 
-    /** @test */
+    #[Test]
     public function it_loads_a_route_with_a_localized_route_key_with_custom_slugs()
     {
         $this->setSupportedLocales([

--- a/tests/Feature/RouteModelBindingTest.php
+++ b/tests/Feature/RouteModelBindingTest.php
@@ -12,7 +12,7 @@ use CodeZero\LocalizedRoutes\Tests\Stubs\Models\ModelOneWithRouteBinding;
 class RouteModelBindingTest extends TestCase
 {
     #[Test]
-    public function it_loads_a_route_with_a_localized_route_key_based_on_the_active_locale()
+    public function it_loads_a_route_with_a_localized_route_key_based_on_the_active_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
 
@@ -46,7 +46,7 @@ class RouteModelBindingTest extends TestCase
     }
 
     #[Test]
-    public function it_loads_a_route_with_a_custom_localized_route_key_based_on_the_active_locale()
+    public function it_loads_a_route_with_a_custom_localized_route_key_based_on_the_active_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
 
@@ -80,7 +80,7 @@ class RouteModelBindingTest extends TestCase
     }
 
     #[Test]
-    public function it_loads_a_route_with_a_localized_route_key_with_custom_slugs()
+    public function it_loads_a_route_with_a_localized_route_key_with_custom_slugs(): void
     {
         $this->setSupportedLocales([
             'en' => 'english',

--- a/tests/Feature/RouteModelBindingTest.php
+++ b/tests/Feature/RouteModelBindingTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Route;
 use CodeZero\LocalizedRoutes\Tests\TestCase;
 use CodeZero\LocalizedRoutes\Tests\Stubs\Models\ModelOneWithRouteBinding;
 
-class RouteModelBindingTest extends TestCase
+final class RouteModelBindingTest extends TestCase
 {
     #[Test]
     public function it_loads_a_route_with_a_localized_route_key_based_on_the_active_locale(): void

--- a/tests/Unit/Illuminate/Routing/RedirectorTest.php
+++ b/tests/Unit/Illuminate/Routing/RedirectorTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\URL;
 class RedirectorTest extends TestCase
 {
     #[Test]
-    public function it_redirects_to_a_named_route_in_the_current_locale()
+    public function it_redirects_to_a_named_route_in_the_current_locale(): void
     {
         $this->setAppLocale('en');
 
@@ -26,7 +26,7 @@ class RedirectorTest extends TestCase
     }
 
     #[Test]
-    public function it_redirects_to_a_named_route_in_a_specific_locale()
+    public function it_redirects_to_a_named_route_in_a_specific_locale(): void
     {
         $this->setAppLocale('en');
 
@@ -42,7 +42,7 @@ class RedirectorTest extends TestCase
     }
 
     #[Test]
-    public function it_redirects_to_a_signed_route_in_the_current_locale()
+    public function it_redirects_to_a_signed_route_in_the_current_locale(): void
     {
         $this->setAppLocale('en');
 
@@ -57,7 +57,7 @@ class RedirectorTest extends TestCase
     }
 
     #[Test]
-    public function it_redirects_to_a_signed_route_in_a_specific_locale()
+    public function it_redirects_to_a_signed_route_in_a_specific_locale(): void
     {
         $this->setAppLocale('en');
 
@@ -73,7 +73,7 @@ class RedirectorTest extends TestCase
     }
 
     #[Test]
-    public function it_redirects_to_a_temporary_signed_route_in_the_current_locale()
+    public function it_redirects_to_a_temporary_signed_route_in_the_current_locale(): void
     {
         $this->setAppLocale('en');
 
@@ -88,7 +88,7 @@ class RedirectorTest extends TestCase
     }
 
     #[Test]
-    public function it_redirects_to_a_temporary_signed_route_in_a_specific_locale()
+    public function it_redirects_to_a_temporary_signed_route_in_a_specific_locale(): void
     {
         $this->setAppLocale('en');
 

--- a/tests/Unit/Illuminate/Routing/RedirectorTest.php
+++ b/tests/Unit/Illuminate/Routing/RedirectorTest.php
@@ -2,6 +2,7 @@
 
 namespace CodeZero\LocalizedRoutes\Tests\Unit\Illuminate\Routing;
 
+use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\Tests\TestCase;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Route;
@@ -9,7 +10,7 @@ use Illuminate\Support\Facades\URL;
 
 class RedirectorTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_redirects_to_a_named_route_in_the_current_locale()
     {
         $this->setAppLocale('en');
@@ -24,7 +25,7 @@ class RedirectorTest extends TestCase
         $response->assertRedirect('/en/target/route');
     }
 
-    /** @test */
+    #[Test]
     public function it_redirects_to_a_named_route_in_a_specific_locale()
     {
         $this->setAppLocale('en');
@@ -40,7 +41,7 @@ class RedirectorTest extends TestCase
         $response->assertRedirect('/nl/target/route');
     }
 
-    /** @test */
+    #[Test]
     public function it_redirects_to_a_signed_route_in_the_current_locale()
     {
         $this->setAppLocale('en');
@@ -55,7 +56,7 @@ class RedirectorTest extends TestCase
         $response->assertRedirect(URL::signedRoute('target.route'));
     }
 
-    /** @test */
+    #[Test]
     public function it_redirects_to_a_signed_route_in_a_specific_locale()
     {
         $this->setAppLocale('en');
@@ -71,7 +72,7 @@ class RedirectorTest extends TestCase
         $response->assertRedirect(URL::signedRoute('target.route', [], null, true, 'nl'));
     }
 
-    /** @test */
+    #[Test]
     public function it_redirects_to_a_temporary_signed_route_in_the_current_locale()
     {
         $this->setAppLocale('en');
@@ -86,7 +87,7 @@ class RedirectorTest extends TestCase
         $response->assertRedirect(URL::temporarySignedRoute('target.route', now()->addMinutes(30)));
     }
 
-    /** @test */
+    #[Test]
     public function it_redirects_to_a_temporary_signed_route_in_a_specific_locale()
     {
         $this->setAppLocale('en');

--- a/tests/Unit/Illuminate/Routing/RedirectorTest.php
+++ b/tests/Unit/Illuminate/Routing/RedirectorTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 
-class RedirectorTest extends TestCase
+final class RedirectorTest extends TestCase
 {
     #[Test]
     public function it_redirects_to_a_named_route_in_the_current_locale(): void

--- a/tests/Unit/Illuminate/Routing/UrlGeneratorTest.php
+++ b/tests/Unit/Illuminate/Routing/UrlGeneratorTest.php
@@ -17,14 +17,14 @@ use Symfony\Component\Routing\Exception\RouteNotFoundException;
 class UrlGeneratorTest extends TestCase
 {
     #[Test]
-    public function it_binds_our_custom_url_generator_class()
+    public function it_binds_our_custom_url_generator_class(): void
     {
         $this->assertInstanceOf(UrlGenerator::class, App::make('url'));
         $this->assertInstanceOf(UrlGenerator::class, App::make('redirect')->getUrlGenerator());
     }
 
     #[Test]
-    public function it_gets_the_url_of_a_named_route_as_usual()
+    public function it_gets_the_url_of_a_named_route_as_usual(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -47,7 +47,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_the_url_of_a_route_in_the_current_locale_if_the_given_route_name_does_not_exist()
+    public function it_gets_the_url_of_a_route_in_the_current_locale_if_the_given_route_name_does_not_exist(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -58,7 +58,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_throws_if_no_valid_route_can_be_found()
+    public function it_throws_if_no_valid_route_can_be_found(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -71,7 +71,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_throws_if_no_valid_localized_route_can_be_found()
+    public function it_throws_if_no_valid_localized_route_can_be_found(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -84,7 +84,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_the_url_of_a_route_in_the_given_locale()
+    public function it_gets_the_url_of_a_route_in_the_given_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -98,7 +98,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_the_url_of_a_route_in_the_given_locale_when_using_custom_domains()
+    public function it_gets_the_url_of_a_route_in_the_given_locale_when_using_custom_domains(): void
     {
         $this->setSupportedLocales([
             'en' => 'en.domain.test',
@@ -115,7 +115,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_the_url_of_a_route_in_the_given_locale_when_using_custom_slugs()
+    public function it_gets_the_url_of_a_route_in_the_given_locale_when_using_custom_slugs(): void
     {
         $this->setSupportedLocales([
             'en' => 'english',
@@ -131,7 +131,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_always_gets_the_url_of_a_localized_route_if_a_locale_is_specified()
+    public function it_always_gets_the_url_of_a_localized_route_if_a_locale_is_specified(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -143,7 +143,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_a_registered_non_localized_url_if_a_localized_version_does_not_exist()
+    public function it_returns_a_registered_non_localized_url_if_a_localized_version_does_not_exist(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -155,7 +155,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_throws_if_no_valid_route_can_be_found_for_the_given_locale()
+    public function it_throws_if_no_valid_route_can_be_found_for_the_given_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -168,7 +168,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    function it_uses_a_fallback_locale_when_the_requested_locale_is_unsupported()
+    function it_uses_a_fallback_locale_when_the_requested_locale_is_unsupported(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -183,7 +183,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_uses_a_fallback_locale_when_the_requested_locale_is_not_registered()
+    public function it_uses_a_fallback_locale_when_the_requested_locale_is_not_registered(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -196,7 +196,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_throws_if_you_do_not_specify_a_name_for_a_localized_route()
+    public function it_throws_if_you_do_not_specify_a_name_for_a_localized_route(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -209,7 +209,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_a_url_for_a_route_with_a_default_localized_route_key()
+    public function it_generates_a_url_for_a_route_with_a_default_localized_route_key(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -232,7 +232,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_a_url_for_a_route_with_a_custom_localized_route_key()
+    public function it_generates_a_url_for_a_route_with_a_custom_localized_route_key(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -255,7 +255,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_a_signed_route_url_for_the_current_locale()
+    public function it_generates_a_signed_route_url_for_the_current_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -277,7 +277,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_a_signed_route_url_for_a_specific_locale()
+    public function it_generates_a_signed_route_url_for_a_specific_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -299,7 +299,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_a_temporary_signed_route_url_for_the_current_locale()
+    public function it_generates_a_temporary_signed_route_url_for_the_current_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -320,7 +320,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_a_temporary_signed_route_url_for_a_specific_locale()
+    public function it_generates_a_temporary_signed_route_url_for_a_specific_locale(): void
     {
         $this->setSupportedLocales(['en', 'nl']);
         $this->setAppLocale('en');
@@ -342,7 +342,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_throws_a_route_not_found_exception_for_missing_route_names_when_generating_a_route_url()
+    public function it_throws_a_route_not_found_exception_for_missing_route_names_when_generating_a_route_url(): void
     {
         $this->expectException(RouteNotFoundException::class);
 
@@ -350,7 +350,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function the_app_locale_is_correctly_restored_when_catching_a_route_not_found_exception_when_generating_a_route_url()
+    public function the_app_locale_is_correctly_restored_when_catching_a_route_not_found_exception_when_generating_a_route_url(): void
     {
         $this->setAppLocale('en');
 
@@ -362,7 +362,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_throws_a_route_not_found_exception_for_missing_route_names_when_generating_a_signed_route_url()
+    public function it_throws_a_route_not_found_exception_for_missing_route_names_when_generating_a_signed_route_url(): void
     {
         $this->expectException(RouteNotFoundException::class);
 
@@ -370,7 +370,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function the_app_locale_is_correctly_restored_when_catching_a_route_not_found_exception_when_generating_a_signed_route_url()
+    public function the_app_locale_is_correctly_restored_when_catching_a_route_not_found_exception_when_generating_a_signed_route_url(): void
     {
         $this->setAppLocale('en');
 
@@ -382,7 +382,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_throws_a_route_not_found_exception_for_missing_route_names_when_generating_a_temporary_signed_route_url()
+    public function it_throws_a_route_not_found_exception_for_missing_route_names_when_generating_a_temporary_signed_route_url(): void
     {
         $this->expectException(RouteNotFoundException::class);
 
@@ -390,7 +390,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function the_app_locale_is_correctly_restored_when_catching_a_route_not_found_exception_when_generating_a_temporary_signed_route_url()
+    public function the_app_locale_is_correctly_restored_when_catching_a_route_not_found_exception_when_generating_a_temporary_signed_route_url(): void
     {
         $this->setAppLocale('en');
 
@@ -402,7 +402,7 @@ class UrlGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function it_allows_routes_to_be_cached()
+    public function it_allows_routes_to_be_cached(): void
     {
         $this->withoutExceptionHandling();
         $this->setSupportedLocales(['en']);

--- a/tests/Unit/Illuminate/Routing/UrlGeneratorTest.php
+++ b/tests/Unit/Illuminate/Routing/UrlGeneratorTest.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\URL;
 use InvalidArgumentException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
-class UrlGeneratorTest extends TestCase
+final class UrlGeneratorTest extends TestCase
 {
     #[Test]
     public function it_binds_our_custom_url_generator_class(): void

--- a/tests/Unit/Illuminate/Routing/UrlGeneratorTest.php
+++ b/tests/Unit/Illuminate/Routing/UrlGeneratorTest.php
@@ -2,6 +2,7 @@
 
 namespace CodeZero\LocalizedRoutes\Tests\Unit\Illuminate\Routing;
 
+use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\Tests\Stubs\Controller;
 use CodeZero\LocalizedRoutes\Tests\Stubs\Models\ModelOneWithRouteBinding;
 use CodeZero\LocalizedRoutes\Tests\TestCase;
@@ -15,14 +16,14 @@ use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 class UrlGeneratorTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_binds_our_custom_url_generator_class()
     {
         $this->assertInstanceOf(UrlGenerator::class, App::make('url'));
         $this->assertInstanceOf(UrlGenerator::class, App::make('redirect')->getUrlGenerator());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_the_url_of_a_named_route_as_usual()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -45,7 +46,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals(URL::to('nl/route/name'), URL::route('nl.route.name'));
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_the_url_of_a_route_in_the_current_locale_if_the_given_route_name_does_not_exist()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -56,7 +57,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals(URL::to('en/route'), URL::route('route.name'));
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_if_no_valid_route_can_be_found()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -69,7 +70,7 @@ class UrlGeneratorTest extends TestCase
         URL::route('route');
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_if_no_valid_localized_route_can_be_found()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -82,7 +83,7 @@ class UrlGeneratorTest extends TestCase
         URL::route('route.name');
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_the_url_of_a_route_in_the_given_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -96,7 +97,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals(URL::to('nl/route'), URL::route('nl.route.name', [], true, 'nl'));
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_the_url_of_a_route_in_the_given_locale_when_using_custom_domains()
     {
         $this->setSupportedLocales([
@@ -113,7 +114,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals('http://nl.domain.test/route', URL::route('nl.route.name', [], true, 'nl'));
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_the_url_of_a_route_in_the_given_locale_when_using_custom_slugs()
     {
         $this->setSupportedLocales([
@@ -129,7 +130,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals(URL::to('dutch/route'), URL::route('nl.route.name', [], true, 'nl'));
     }
 
-    /** @test */
+    #[Test]
     public function it_always_gets_the_url_of_a_localized_route_if_a_locale_is_specified()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -141,7 +142,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals(URL::to('nl/route'), URL::route('route.name', [], true, 'nl'));
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_a_registered_non_localized_url_if_a_localized_version_does_not_exist()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -153,7 +154,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals(URL::to('route'), URL::route('route.name', [], true, 'en'));
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_if_no_valid_route_can_be_found_for_the_given_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -166,7 +167,7 @@ class UrlGeneratorTest extends TestCase
         URL::route('en.route.name', [], true, 'nl');
     }
 
-    /** @test */
+    #[Test]
     function it_uses_a_fallback_locale_when_the_requested_locale_is_unsupported()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -181,7 +182,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals(URL::to('en/route'), URL::route('route', [], true, 'fr'));
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_a_fallback_locale_when_the_requested_locale_is_not_registered()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -194,7 +195,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals(URL::to('en/route'), URL::route('route', [], true, 'nl'));
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_if_you_do_not_specify_a_name_for_a_localized_route()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -207,7 +208,7 @@ class UrlGeneratorTest extends TestCase
         URL::route('en.', [], true, 'en');
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_a_url_for_a_route_with_a_default_localized_route_key()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -230,7 +231,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals(URL::to('nl/route/nl-slug'), URL::route('route.name', [$model], true, 'nl'));
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_a_url_for_a_route_with_a_custom_localized_route_key()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -253,7 +254,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals(URL::to('nl/route/nl-slug'), URL::route('route.name', [$model], true, 'nl'));
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_a_signed_route_url_for_the_current_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -275,7 +276,7 @@ class UrlGeneratorTest extends TestCase
         $this->get($tamperedUrl)->assertSee('Invalid Signature');
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_a_signed_route_url_for_a_specific_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -297,7 +298,7 @@ class UrlGeneratorTest extends TestCase
         $this->get($tamperedUrl)->assertSee('Invalid Signature');
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_a_temporary_signed_route_url_for_the_current_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -318,7 +319,7 @@ class UrlGeneratorTest extends TestCase
         $this->get($expiredUrl)->assertSee('Expired Signature');
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_a_temporary_signed_route_url_for_a_specific_locale()
     {
         $this->setSupportedLocales(['en', 'nl']);
@@ -340,7 +341,7 @@ class UrlGeneratorTest extends TestCase
         $this->get($expiredUrl)->assertSee('Expired Signature');
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_a_route_not_found_exception_for_missing_route_names_when_generating_a_route_url()
     {
         $this->expectException(RouteNotFoundException::class);
@@ -348,7 +349,7 @@ class UrlGeneratorTest extends TestCase
         URL::route('missing.route');
     }
 
-    /** @test */
+    #[Test]
     public function the_app_locale_is_correctly_restored_when_catching_a_route_not_found_exception_when_generating_a_route_url()
     {
         $this->setAppLocale('en');
@@ -360,7 +361,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals('en', App::getLocale());
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_a_route_not_found_exception_for_missing_route_names_when_generating_a_signed_route_url()
     {
         $this->expectException(RouteNotFoundException::class);
@@ -368,7 +369,7 @@ class UrlGeneratorTest extends TestCase
         URL::signedRoute('missing.route');
     }
 
-    /** @test */
+    #[Test]
     public function the_app_locale_is_correctly_restored_when_catching_a_route_not_found_exception_when_generating_a_signed_route_url()
     {
         $this->setAppLocale('en');
@@ -380,7 +381,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals('en', App::getLocale());
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_a_route_not_found_exception_for_missing_route_names_when_generating_a_temporary_signed_route_url()
     {
         $this->expectException(RouteNotFoundException::class);
@@ -388,7 +389,7 @@ class UrlGeneratorTest extends TestCase
         URL::temporarySignedRoute('missing.route', now()->addMinutes(30));
     }
 
-    /** @test */
+    #[Test]
     public function the_app_locale_is_correctly_restored_when_catching_a_route_not_found_exception_when_generating_a_temporary_signed_route_url()
     {
         $this->setAppLocale('en');
@@ -400,7 +401,7 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals('en', App::getLocale());
     }
 
-    /** @test */
+    #[Test]
     public function it_allows_routes_to_be_cached()
     {
         $this->withoutExceptionHandling();

--- a/tests/Unit/LocaleConfigTest.php
+++ b/tests/Unit/LocaleConfigTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\LocaleConfig;
 use CodeZero\LocalizedRoutes\Tests\TestCase;
 
-class LocaleConfigTest extends TestCase
+final class LocaleConfigTest extends TestCase
 {
     #[Test]
     public function it_gets_the_supported_locales(): void

--- a/tests/Unit/LocaleConfigTest.php
+++ b/tests/Unit/LocaleConfigTest.php
@@ -9,7 +9,7 @@ use CodeZero\LocalizedRoutes\Tests\TestCase;
 class LocaleConfigTest extends TestCase
 {
     #[Test]
-    public function it_gets_the_supported_locales()
+    public function it_gets_the_supported_locales(): void
     {
         $config = new LocaleConfig(['supported_locales' => null]);
         $this->assertEquals([], $config->getSupportedLocales());
@@ -25,7 +25,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_sets_the_supported_locales()
+    public function it_sets_the_supported_locales(): void
     {
         $config = new LocaleConfig(['supported_locales' => null]);
         $config->setSupportedLocales(['en' => 'english', 'nl' => 'dutch']);
@@ -33,7 +33,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_the_omitted_locale()
+    public function it_gets_the_omitted_locale(): void
     {
         $config = new LocaleConfig(['omitted_locale' => null]);
         $this->assertEquals(null, $config->getOmittedLocale());
@@ -43,7 +43,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_sets_the_omitted_locale()
+    public function it_sets_the_omitted_locale(): void
     {
         $config = new LocaleConfig(['omitted_locale' => null]);
         $config->setOmittedLocale('en');
@@ -51,7 +51,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_the_fallback_locale()
+    public function it_gets_the_fallback_locale(): void
     {
         $config = new LocaleConfig(['fallback_locale' => null]);
         $this->assertEquals(null, $config->getFallbackLocale());
@@ -61,7 +61,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_sets_the_fallback_locale()
+    public function it_sets_the_fallback_locale(): void
     {
         $config = new LocaleConfig(['fallback_locale' => null]);
         $config->setFallbackLocale('en');
@@ -69,7 +69,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_the_route_action()
+    public function it_gets_the_route_action(): void
     {
         $config = new LocaleConfig(['route_action' => null]);
         $this->assertEquals(null, $config->getRouteAction());
@@ -79,7 +79,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_sets_the_route_action()
+    public function it_sets_the_route_action(): void
     {
         $config = new LocaleConfig(['route_action' => null]);
         $config->setRouteAction('locale');
@@ -87,7 +87,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_the_locales()
+    public function it_gets_the_locales(): void
     {
         $config = new LocaleConfig(['supported_locales' => null]);
         $this->assertEquals([], $config->getLocales());
@@ -103,7 +103,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_finds_a_slug_by_its_locale()
+    public function it_finds_a_slug_by_its_locale(): void
     {
         $config = new LocaleConfig(['supported_locales' => null]);
         $this->assertEquals(null, $config->findSlugByLocale('en'));
@@ -122,7 +122,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_finds_a_domain_by_its_locale()
+    public function it_finds_a_domain_by_its_locale(): void
     {
         $config = new LocaleConfig(['supported_locales' => null]);
         $this->assertEquals(null, $config->findDomainByLocale('en'));
@@ -139,7 +139,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_finds_a_locale_by_its_slug()
+    public function it_finds_a_locale_by_its_slug(): void
     {
         $config = new LocaleConfig(['supported_locales' => null]);
         $this->assertEquals(null, $config->findLocaleBySlug('en'));
@@ -158,7 +158,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_finds_a_locale_by_its_domain()
+    public function it_finds_a_locale_by_its_domain(): void
     {
         $config = new LocaleConfig(['supported_locales' => null]);
         $this->assertEquals(null, $config->findLocaleByDomain('english.test'));
@@ -177,7 +177,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_checks_if_there_are_any_locales_configured()
+    public function it_checks_if_there_are_any_locales_configured(): void
     {
         $config = new LocaleConfig(['supported_locales' => null]);
         $this->assertFalse($config->hasLocales());
@@ -193,7 +193,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_checks_if_custom_slugs_are_configured()
+    public function it_checks_if_custom_slugs_are_configured(): void
     {
         $config = new LocaleConfig(['supported_locales' => null]);
         $this->assertFalse($config->hasCustomSlugs());
@@ -209,7 +209,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_checks_if_custom_domains_are_configured()
+    public function it_checks_if_custom_domains_are_configured(): void
     {
         $config = new LocaleConfig(['supported_locales' => null]);
         $this->assertFalse($config->hasCustomDomains());
@@ -225,7 +225,7 @@ class LocaleConfigTest extends TestCase
     }
 
     #[Test]
-    public function it_checks_if_a_locale_is_supported()
+    public function it_checks_if_a_locale_is_supported(): void
     {
         $config = new LocaleConfig(['supported_locales' => null]);
         $this->assertFalse($config->isSupportedLocale(null));

--- a/tests/Unit/LocaleConfigTest.php
+++ b/tests/Unit/LocaleConfigTest.php
@@ -2,12 +2,13 @@
 
 namespace CodeZero\LocalizedRoutes\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\LocaleConfig;
 use CodeZero\LocalizedRoutes\Tests\TestCase;
 
 class LocaleConfigTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_gets_the_supported_locales()
     {
         $config = new LocaleConfig(['supported_locales' => null]);
@@ -23,7 +24,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals(['en' => 'english.test', 'nl' => 'dutch.test'], $config->getSupportedLocales());
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_the_supported_locales()
     {
         $config = new LocaleConfig(['supported_locales' => null]);
@@ -31,7 +32,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals(['en' => 'english', 'nl' => 'dutch'], $config->getSupportedLocales());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_the_omitted_locale()
     {
         $config = new LocaleConfig(['omitted_locale' => null]);
@@ -41,7 +42,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals('en', $config->getOmittedLocale());
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_the_omitted_locale()
     {
         $config = new LocaleConfig(['omitted_locale' => null]);
@@ -49,7 +50,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals('en', $config->getOmittedLocale());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_the_fallback_locale()
     {
         $config = new LocaleConfig(['fallback_locale' => null]);
@@ -59,7 +60,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals('en', $config->getFallbackLocale());
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_the_fallback_locale()
     {
         $config = new LocaleConfig(['fallback_locale' => null]);
@@ -67,7 +68,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals('en', $config->getFallbackLocale());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_the_route_action()
     {
         $config = new LocaleConfig(['route_action' => null]);
@@ -77,7 +78,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals('locale', $config->getRouteAction());
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_the_route_action()
     {
         $config = new LocaleConfig(['route_action' => null]);
@@ -85,7 +86,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals('locale', $config->getRouteAction());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_the_locales()
     {
         $config = new LocaleConfig(['supported_locales' => null]);
@@ -101,7 +102,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals(['en', 'nl'], $config->getLocales());
     }
 
-    /** @test */
+    #[Test]
     public function it_finds_a_slug_by_its_locale()
     {
         $config = new LocaleConfig(['supported_locales' => null]);
@@ -120,7 +121,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals(null, $config->findSlugByLocale('en'));
     }
 
-    /** @test */
+    #[Test]
     public function it_finds_a_domain_by_its_locale()
     {
         $config = new LocaleConfig(['supported_locales' => null]);
@@ -137,7 +138,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals('english.test', $config->findDomainByLocale('en'));
     }
 
-    /** @test */
+    #[Test]
     public function it_finds_a_locale_by_its_slug()
     {
         $config = new LocaleConfig(['supported_locales' => null]);
@@ -156,7 +157,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals(null, $config->findLocaleBySlug('english.test'));
     }
 
-    /** @test */
+    #[Test]
     public function it_finds_a_locale_by_its_domain()
     {
         $config = new LocaleConfig(['supported_locales' => null]);
@@ -175,7 +176,7 @@ class LocaleConfigTest extends TestCase
         $this->assertEquals('en', $config->findLocaleByDomain('english.test'));
     }
 
-    /** @test */
+    #[Test]
     public function it_checks_if_there_are_any_locales_configured()
     {
         $config = new LocaleConfig(['supported_locales' => null]);
@@ -191,7 +192,7 @@ class LocaleConfigTest extends TestCase
         $this->assertTrue($config->hasLocales());
     }
 
-    /** @test */
+    #[Test]
     public function it_checks_if_custom_slugs_are_configured()
     {
         $config = new LocaleConfig(['supported_locales' => null]);
@@ -207,7 +208,7 @@ class LocaleConfigTest extends TestCase
         $this->assertFalse($config->hasCustomSlugs());
     }
 
-    /** @test */
+    #[Test]
     public function it_checks_if_custom_domains_are_configured()
     {
         $config = new LocaleConfig(['supported_locales' => null]);
@@ -223,7 +224,7 @@ class LocaleConfigTest extends TestCase
         $this->assertTrue($config->hasCustomDomains());
     }
 
-    /** @test */
+    #[Test]
     public function it_checks_if_a_locale_is_supported()
     {
         $config = new LocaleConfig(['supported_locales' => null]);

--- a/tests/Unit/Middleware/LocaleHandlerTest.php
+++ b/tests/Unit/Middleware/LocaleHandlerTest.php
@@ -13,7 +13,7 @@ use Mockery;
 class LocaleHandlerTest extends TestCase
 {
     #[Test]
-    public function it_loops_through_the_detectors_and_returns_the_first_supported_locale()
+    public function it_loops_through_the_detectors_and_returns_the_first_supported_locale(): void
     {
         $supportedLocales = ['en', 'nl'];
         $detectors = [
@@ -28,7 +28,7 @@ class LocaleHandlerTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_the_first_match_if_an_array_of_locales_is_detected()
+    public function it_returns_the_first_match_if_an_array_of_locales_is_detected(): void
     {
         $supportedLocales = ['en', 'nl'];
         $detectors = [
@@ -41,7 +41,7 @@ class LocaleHandlerTest extends TestCase
     }
 
     #[Test]
-    public function trusted_detectors_ignore_supported_locales_and_may_set_any_locale()
+    public function trusted_detectors_ignore_supported_locales_and_may_set_any_locale(): void
     {
         $supportedLocales = ['en'];
         $detectors = [
@@ -57,7 +57,7 @@ class LocaleHandlerTest extends TestCase
     }
 
     #[Test]
-    public function it_skips_null_and_false_and_empty_values()
+    public function it_skips_null_and_false_and_empty_values(): void
     {
         App::instance(Detector::class, Mockery::mock(Detector::class)->allows()->detect()->andReturns('')->getMock());
 
@@ -77,7 +77,7 @@ class LocaleHandlerTest extends TestCase
     }
 
     #[Test]
-    public function it_skips_null_and_false_and_empty_values_from_trusted_detectors()
+    public function it_skips_null_and_false_and_empty_values_from_trusted_detectors(): void
     {
         App::instance(Detector::class, Mockery::mock(Detector::class)->allows()->detect()->andReturns('')->getMock());
 
@@ -100,7 +100,7 @@ class LocaleHandlerTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_false_if_no_supported_locale_could_be_detected()
+    public function it_returns_false_if_no_supported_locale_could_be_detected(): void
     {
         $supportedLocales = ['en'];
         $detectors = [
@@ -115,7 +115,7 @@ class LocaleHandlerTest extends TestCase
     }
 
     #[Test]
-    public function it_loops_through_the_stores_and_calls_the_store_method_with_the_given_locale()
+    public function it_loops_through_the_stores_and_calls_the_store_method_with_the_given_locale(): void
     {
         $stores = [
             Mockery::mock(Store::class)->expects()->store('nl')->once()->getMock(),
@@ -129,7 +129,7 @@ class LocaleHandlerTest extends TestCase
     }
 
     #[Test]
-    public function it_accepts_class_names_instead_of_instances_in_the_constructor()
+    public function it_accepts_class_names_instead_of_instances_in_the_constructor(): void
     {
         App::instance(Store::class, Mockery::mock(Store::class)->expects()->store('nl')->once()->getMock());
         App::instance(Detector::class, Mockery::mock(Detector::class)->expects()->detect()->once()->getMock());

--- a/tests/Unit/Middleware/LocaleHandlerTest.php
+++ b/tests/Unit/Middleware/LocaleHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace CodeZero\LocalizedRoutes\Tests\Unit\Middleware;
 
+use PHPUnit\Framework\Attributes\Test;
 use CodeZero\LocalizedRoutes\Middleware\Detectors\Detector;
 use CodeZero\LocalizedRoutes\Middleware\LocaleHandler;
 use CodeZero\LocalizedRoutes\Middleware\Stores\Store;
@@ -11,7 +12,7 @@ use Mockery;
 
 class LocaleHandlerTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_loops_through_the_detectors_and_returns_the_first_supported_locale()
     {
         $supportedLocales = ['en', 'nl'];
@@ -26,7 +27,7 @@ class LocaleHandlerTest extends TestCase
         $this->assertEquals('nl', $localeHandler->detect());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_the_first_match_if_an_array_of_locales_is_detected()
     {
         $supportedLocales = ['en', 'nl'];
@@ -39,7 +40,7 @@ class LocaleHandlerTest extends TestCase
         $this->assertEquals('nl', $localeHandler->detect());
     }
 
-    /** @test */
+    #[Test]
     public function trusted_detectors_ignore_supported_locales_and_may_set_any_locale()
     {
         $supportedLocales = ['en'];
@@ -55,7 +56,7 @@ class LocaleHandlerTest extends TestCase
         $this->assertEquals('nl', $localeHandler->detect());
     }
 
-    /** @test */
+    #[Test]
     public function it_skips_null_and_false_and_empty_values()
     {
         App::instance(Detector::class, Mockery::mock(Detector::class)->allows()->detect()->andReturns('')->getMock());
@@ -75,7 +76,7 @@ class LocaleHandlerTest extends TestCase
         $this->assertEquals('nl', $localeHandler->detect());
     }
 
-    /** @test */
+    #[Test]
     public function it_skips_null_and_false_and_empty_values_from_trusted_detectors()
     {
         App::instance(Detector::class, Mockery::mock(Detector::class)->allows()->detect()->andReturns('')->getMock());
@@ -98,7 +99,7 @@ class LocaleHandlerTest extends TestCase
         $this->assertEquals('nl', $localeHandler->detect());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_false_if_no_supported_locale_could_be_detected()
     {
         $supportedLocales = ['en'];
@@ -113,7 +114,7 @@ class LocaleHandlerTest extends TestCase
         $this->assertNull($localeHandler->detect());
     }
 
-    /** @test */
+    #[Test]
     public function it_loops_through_the_stores_and_calls_the_store_method_with_the_given_locale()
     {
         $stores = [
@@ -127,7 +128,7 @@ class LocaleHandlerTest extends TestCase
         $localeHandler->store('nl');
     }
 
-    /** @test */
+    #[Test]
     public function it_accepts_class_names_instead_of_instances_in_the_constructor()
     {
         App::instance(Store::class, Mockery::mock(Store::class)->expects()->store('nl')->once()->getMock());

--- a/tests/Unit/Middleware/LocaleHandlerTest.php
+++ b/tests/Unit/Middleware/LocaleHandlerTest.php
@@ -10,7 +10,7 @@ use CodeZero\LocalizedRoutes\Tests\TestCase;
 use Illuminate\Support\Facades\App;
 use Mockery;
 
-class LocaleHandlerTest extends TestCase
+final class LocaleHandlerTest extends TestCase
 {
     #[Test]
     public function it_loops_through_the_detectors_and_returns_the_first_supported_locale(): void


### PR DESCRIPTION
This pull request contains changes for upgrading to [PHPUnit 10](https://phpunit.de/announcements/phpunit-10.html) automated by the [PHPUnit 10 Shift](https://laravelshift.com/upgrade-phpunit-10).

**Before merging**, you need to:

- Checkout the `shift-111775` branch
- Review **all** pull request comments for additional changes
- Run `composer update` (if the scripts fail, try with `--no-scripts`)
- Run your tests suite: `vendor/bin/phpunit`

If there were changes you felt could have been automated, please reply to the follow-up email with your feedback or on [Twitter](https://twitter.com/laravelshift).
